### PR TITLE
Create initial blueprints for deploying Kubeflow.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# Reset various kpt values to default values and remove other
+# files that shouldn't be included in PRs
+# TODO(jlewi): We should add a test to make sure changed values don't get checked in
+# We don't run it in generate because we don't want to force all developers to install kpt
+clean-for-pr:
+	rm -rf kubeflow/.build
+	rm -rf management/.build
+	
+	rm -rf kubeflow/upstream/manifests
+	rm -rf management/upstream/management
+	
+
+	kpt cfg set ./kubeflow/instance name KUBEFLOW-NAME
+	kpt cfg set ./kubeflow/instance gcloud.core.project PROJECT
+	kpt cfg set ./kubeflow/instance mgmt-ctxt MANAGEMENT-CTXT
+
+	kpt cfg set ./management/instance name MANAGEMENT-NAME
+	kpt cfg set ./management/instance gcloud.core.project HOST_PROJECT
+	kpt cfg set ./management/instance host_project HOST_PROJECT
+	kpt cfg set ./management/instance host_id_pool HOST_PROJECT.svc.id.goog
+	kpt cfg set ./management/instance managed_project MANAGED_PROJECT
+	kpt cfg set ./management/instance managed_gsa_name MANAGED-GSA-NAME
+	

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# gcp-blueprints
-Blueprints for Deploying Kubeflow on Google Cloud Platform and Anthos
+# Kubeflow Blueprint
+
+Blueprints for Kubeflow.
+
+Kubeflow is deployed as follows
+
+* A mangement cluster is setup using the manifests in **management**
+  * The management cluster runs KCC and optionally ConfigSync
+  * The management cluster is used to create all GCP resources for Kubeflow (e.g. the GKE cluster)
+  * A single management cluster could be used for multiple projects or multiple KF deployments
+
+* Once the Kubeflow cluster is created we use kustomize to deploy the KF applications on it.
+
+For more information about blueprints refer to the [kpt blueprint guide](https://googlecontainertools.github.io/kpt/guides/producer/blueprint/)
+
+## Getting Started
+
+1. Use the [management](./management/README.md) blueprint to spin up a management
+   cluster
+1. Use the [kubeflow](./kubeflow/README.md) blueprint to create a Kubeflow deployment.

--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -1,0 +1,161 @@
+# The kname of the context for the management cluster
+# These can be read using yq from the settings file.
+#
+# If you don't have yq 
+MGMTCTXT=$(shell yq r ./instance/settings.yaml mgmt-ctxt)
+# The name of the context for your Kubeflow cluster
+NAME=$(shell yq r ./instance/settings.yaml name)
+KFCTXT=$(NAME)
+
+# Path to kustomize directories
+GCP_CONFIG=./instance/gcp_config
+KF_DIR=./instance/kustomize
+
+APP_DIR=.
+MANIFESTS_DIR=./upstream/manifests
+
+# TODO(https://github.com/GoogleContainerTools/kpt/issues/539): 
+# Using a subdirectory fo the current directory breaks our ability to run kpt set .
+# So as a hack we use a $(BUILD_DIR)/ directory in the parent directory.
+BUILD_DIR=.build
+
+# The URL you want to fetch manifests from
+MANIFESTS_URL=https://github.com/jlewi/manifests.git@blueprints
+
+# Print out the context
+.PHONY: echo
+echo-ctxt:
+	@echo MGMTCTXT=$(MGMTCTXT)
+	@echo KFCTXT=$(KFCTXT)
+
+# Get packages
+.PHONY: get-packages
+get-pkg:
+	# TODO(jlewi): We should switch to using upstream kubeflow/manifests and pin
+	# to a specific version
+	# TODO(jlewi): We should think about how we layout packages in kubeflow/manifests so
+	# users don't end up pulling tests or other things they don't need.
+	mkdir -p  ./upstream
+	kpt pkg get $(MANIFESTS_URL) $(MANIFESTS_DIR)
+	rm -rf $(MANIFESTS_DIR)/tests
+	# TODO(jlewi): Package appears to cause problems for kpt. We should delete in the upstream
+	# since its not needed anymore.
+	# https://github.com/GoogleContainerTools/kpt/issues/539
+	rm -rf $(MANIFESTS_DIR)/common/ambassador
+		
+.PHONY: hydrate
+apply-gcp: hydrate-gcp
+	# Apply management resources
+	kubectl --context=$(MGMTCTXT) apply -f ./$(BUILD_DIR)/gcp_config
+
+.PHONY: apply-asm
+apply-asm: hydrate-asm
+	# We need to apply the CRD definitions first
+	kubectl --context=${KFCTXT} apply --recursive=true -f ./$(BUILD_DIR)/istio/Base/Base.yaml
+	kubectl --context=${KFCTXT} apply --recursive=true -f ./$(BUILD_DIR)/istio/Base
+	# TODO(jlewi): Should we use the newer version in asm/asm
+	# istioctl manifest --context=${KFCTXT} apply -f ./manifests/gcp/v2/asm/istio-operator.yaml 
+	# TODO(jlewi): Switch to anthoscli once it supports generating manifests 
+	# anthoscli apply -f ./manifests/gcp/v2/asm/istio-operator.yaml 
+
+.PHONY: apply-kubeflow
+apply-kubeflow: hydrate-kubeflow
+	# Apply kubeflow apps
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/namespaces
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/kubeflow-istio
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/metacontroller
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/application
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/cloud-endpoints
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/iap-ingress
+	# Due to https://github.com/jetstack/cert-manager/issues/2208
+	# We need to skip validation on Kubernetes 1.14
+	kubectl --context=$(KFCTXT) apply --validate=false -f ./$(BUILD_DIR)/cert-manager-crds
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/cert-manager-kube-system-resources	
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/cert-manager
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/kubeflow-apps
+	# Create the kubeflow-issuer last to give cert-manager time deploy
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/kubeflow-issuer
+
+# TODO(jlewi): If we use prune does that give us a complete upgrade solution?
+# TODO(jlewi): Should we insert appropriate wait statements to wait for various services to
+# be available before continuing?
+.PHONY: apply
+apply: clean-build check-iap apply-gcp wait-gcp create-ctxt apply-asm apply-kubeflow iap-secret
+
+.PHONY: hydrate-gcp
+hydrate-gcp:
+	# ***********************************************************************************
+	# Hydrate cnrm
+	mkdir -p $(BUILD_DIR)/gcp_config 
+	kustomize build -o $(BUILD_DIR)/gcp_config $(GCP_CONFIG)
+
+.PHONY: hydrate-asm
+hydrate-asm:	
+	#************************************************************************************
+	# hydrate asm
+	istioctl manifest generate -f $(MANIFESTS_DIR)/gcp/v2/asm/istio-operator.yaml -o $(BUILD_DIR)/istio
+
+.PHONY: hydrate-kubeflow
+hydrate-kubeflow:	
+	#************************************************************************************
+	# Hydrate kubeflow applications
+	mkdir -p $(BUILD_DIR)/namespaces
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/namespaces  ${KF_DIR}/namespaces
+
+	mkdir -p $(BUILD_DIR)/application
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/application $(KF_DIR)/application
+	mkdir -p $(BUILD_DIR)/cert-manager
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/cert-manager $(KF_DIR)/cert-manager
+	mkdir -p $(BUILD_DIR)/cert-manager-crds
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/cert-manager-crds $(KF_DIR)/cert-manager-crds
+	mkdir -p $(BUILD_DIR)/cert-manager-kube-system-resources
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/cert-manager-kube-system-resources $(KF_DIR)/cert-manager-kube-system-resources
+	mkdir -p $(BUILD_DIR)/cloud-endpoints
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/cloud-endpoints $(KF_DIR)/cloud-endpoints
+	mkdir -p $(BUILD_DIR)/iap-ingress
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/iap-ingress $(KF_DIR)/iap-ingress
+	mkdir -p $(BUILD_DIR)/kubeflow-apps
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/kubeflow-apps $(KF_DIR)/kubeflow-apps
+	mkdir -p $(BUILD_DIR)/kubeflow-apps
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/kubeflow-istio $(KF_DIR)/kubeflow-istio
+	mkdir -p $(BUILD_DIR)/metacontroller
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/metacontroller $(KF_DIR)/metacontroller	
+	mkdir -p $(BUILD_DIR)/kubeflow-issuer
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/kubeflow-issuer $(KF_DIR)/kubeflow-issuer
+.PHONY: clean-build
+clean-build:
+	# Delete build because we want to prune any resources which are no longer defined in the manifests
+	rm -rf $(BUILD_DIR)/
+	mkdir -p $(BUILD_DIR)/
+
+# Hydrate all the application directories directories
+# TODO(jlewi): We can't use a kustomization file to combine the top level packages
+# because they might get vars conflicts. Also order is important when applying them.
+.PHONY: hydrate
+hydrate: clean-build hydrate-gcp hydrate-asm hydrate-kubeflow
+	
+
+.PHONY: check-iap 
+check-iap:
+	./hack/check_oauth_secret.sh
+
+# Create the iap secret from environment variables
+# TODO(jlewi): How can we test to make sure CLIENT_ID is set so we don't create an empty secret.
+.PHONY: iap-secret
+iap-secret: check-iap
+	kubectl --context=$(KFCTXT) -n istio-system create secret generic kubeflow-oauth --from-literal=client_id=${CLIENT_ID} --from-literal=client_secret=${CLIENT_SECRET}
+
+.PHONY: wait-gcp
+wait-gcp:
+	kubectl --context=$(MGMTCTXT) wait --for=condition=Ready --timeout=600s  containercluster $(NAME)
+
+# Create a kubeconfig context for the kubeflow cluster
+.PHONY: create-ctxt
+create-ctxt:
+	PROJECT=$(shell yq r ./instance/settings.yaml project) \
+	   REGION=$(shell yq r ./instance/settings.yaml location) \
+	   NAME=$(NAME) ./hack/create_context.sh
+
+# Delete gcp resources
+delete-gcp:
+	kubectl	--context=$(MGMTCTXT) delete -f $(BUILD_DIR)/gcp_config

--- a/kubeflow/README.md
+++ b/kubeflow/README.md
@@ -1,0 +1,135 @@
+# Kubeflow Blueprint
+
+This directory contains a blueprint for creating a Kubeflow deployment.
+
+## Prerequisites
+
+You must have created a management cluster and installed Config Connector. 
+If you don't have a management cluster follow the [instructions](../management/README.md)
+for setting one up. 
+
+Your management cluster must have a namespace setup to administer the GCP project where
+Kubeflow will be deployped. Follow the [instructions](../management/README.md) to create
+one if you haven't already.
+
+
+## Install the required tools
+
+1. Install gcloud components
+
+   ```
+   gcloud components install kpt anthoscli beta
+   gcloud components update
+   ```
+
+1. Follow these [instructions](https://cloud.google.com/service-mesh/docs/gke-install-new-cluster#download_the_installation_file) to
+   install istioctl
+
+## Fetch packages using kpt
+
+1. Fetch the blueprint
+
+   ```
+   kpt pkg get https://github.com/jlewi/kf-templates-gcp.git/kubeflow@master ./
+   ```
+
+   * TODO(jlewi): Change to a Kubeflow repo
+
+
+1. Change to the kubeflow directory
+
+   ```
+   cd kubeflow
+   ```
+
+1. Fetch Kubeflow manifests
+
+   ```
+   make pkg-get
+   ```
+
+  * This generates an error per [GoogleContainerTools/kpt#539](https://github.com/GoogleContainerTools/kpt/issues/539) but it looks like
+    this can be ignored.
+
+  * TODO(jlewi): This is giving an error like the one below but this can be ignored
+
+    ```
+    kpt pkg get https://github.com/jlewi/manifests.git@blueprints ./upstream
+    fetching package / from https://github.com/jlewi/manifests to upstream/manifests
+    Error: resources must be annotated with config.kubernetes.io/index to be written to files
+    ```
+
+## Deploy Kubeflow
+
+1. Set the name of the KUBECONFIG context for the management cluster; this kubecontext will
+   be used to create CNRM resources for your Kubeflow deployment.
+
+   ```
+   kpt cfg set mgmt-ctxt
+   ```
+
+   * Follow the [instructions](../README.md) to create a kubecontext for your managment context
+
+1. Pick a name for the Kubeflow deployment
+
+   ```
+   export KFNAME=<some name>
+   ```
+
+1. Pick a location for the Kubeflow deployment
+
+   ```
+   export LOCATION=<zone or region>
+   export ZONE=<zone for disks>
+   ```
+
+   * Location can be a zone or a region depending on whether you want a regional cluster
+   * We recommend creating regional clusters for higher availability
+   * The [cluster management fee](https://cloud.google.com/kubernetes-engine/pricing) is the same for regional
+     and zonal clusters
+
+   * TODO(jlewi): Metadata and Pipelines are still using zonal disks what do we have to do make that work with regional clusters? For metadata
+     we could use CloudSQL.
+
+1. Set the values for the kubeflow deployment.
+
+   ```
+   kpt cfg set ./upstream/manifests/gcp  name ${KFNAME}
+   kpt cfg set ./upstream/manifests/gcp gcloud.core.project ${MANAGED_PROJECT}   
+   kpt cfg set ./upstream/manifests/gcp  gcloud.compute.zone ${ZONE}
+
+   kpt cfg set ./instance name ${KFNAME}   
+   kpt cfg set ./instance location ${LOCATION}
+   kpt cfg set ./instance gcloud.core.project ${MANAGED_PROJECT}   
+   ```
+
+   * TODO(https://github.com/GoogleContainerTools/kpt/issues/541): If annotations are null kpt chokes. We have such files in manifests which is
+     why we have a separate set statement for manifests once we fix that we should be able to just call it once on root
+
+   * TODO(jlewi): Need to figure out what to do about disk for metadata and pipelines when using regional clusters?. Maybe just 
+     use Cloud SQL?
+
+1. Set environment variables with OAuth Client ID and Secret for IAP
+
+   ```
+   export CLIENT_ID=
+   export CLIENT_SECRET=
+   ```
+
+   * TODO(jlewi): Add link for instructions on creating an OAuth client id
+
+1. Deploy Kubeflow
+
+   ```
+   make apply
+   ```
+
+## Common Problems
+
+1. 502s and backend unhealthy
+
+   * This is often the result of cont configuring ASM correctly (i.e. not specifying the correct
+     ServiceMessh or cluster name)   
+
+  * This usually manifests as the istio proxy in the istio ingressgateway from not being able to start
+    causing the health check failure. 

--- a/kubeflow/hack/check_oauth_secret.sh
+++ b/kubeflow/hack/check_oauth_secret.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Check if CLIENT_ID and CLIENT_SECRET are set
+
+if [ -z "$CLIENT_ID" ] || [ -z "$CLIENT_SECRET" ]; then
+   echo "Error: Environment variables CLIENT_ID and CLIENT_SECRET must be set to the OAuth client id and secret to be used with IAP"
+   exit 1
+fi	

--- a/kubeflow/hack/create_context.sh
+++ b/kubeflow/hack/create_context.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# A simple helper script to create a kubeconfig context for a particular cluster.
+#
+# usage
+# PROJECT=<PROJECT> REGION=<region> NAME=<NAME>
+#
+# TODO(jlewi): Support zonal clusters as well
+set -x 
+
+echo Checking if context ${NAME} exists 
+
+kubectl config use-context ${NAME}
+
+RESULT=$?
+
+if [ ${RESULT} -eq 0 ]; then
+echo kubeconfig context ${NAME} already exists
+exit 0
+fi
+
+set -ex
+
+# TODO test if the context already exists and if it does do nothing
+gcloud --project=${PROJECT} container clusters get-credentials \
+	   --region=${REGION} ${NAME}
+
+# Rename the context
+kubectl config rename-context $(kubectl config current-context) ${NAME}
+
+# Set the namespace to the host project
+kubectl config set-context --current --namespace=kubeflow

--- a/kubeflow/instance/README.md
+++ b/kubeflow/instance/README.md
@@ -1,0 +1,8 @@
+# Overlays
+
+* This directory defines overlays of the vendored packages that customize
+  Kubeflow for your particular use case
+
+* These customizations are stored as overlays("patches") ontop of the vendored
+  packages to make it easy to upgrade the vendored packages while
+  preserving your modfications.

--- a/kubeflow/instance/gcp_config/cluster_patch.yaml
+++ b/kubeflow/instance/gcp_config/cluster_patch.yaml
@@ -1,0 +1,15 @@
+# Define a patch to define user specific values for the cluster
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  clusterName: "PROJECT/us-central1/KUBEFLOW-NAME" # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"},{"name":"name","value":"KUBEFLOW-NAME"},{"name":"location","value":"us-central1"}]}}
+  labels:
+    mesh_id: "PROJECT_us-central1_KUBEFLOW-NAME" # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"},{"name":"name","value":"KUBEFLOW-NAME"},{"name":"location","value":"us-central1"}]}}
+  name: KUBEFLOW-NAME # {"type":"string","x-kustomize":{"setter":{"name":"name","value":"KUBEFLOW-NAME"}}}
+spec:
+  location: us-central1 # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"location","value":"us-central1"}}}
+  workloadIdentityConfig:
+    identityNamespace: PROJECT.svc.id.goog # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"}]}}
+  nodeConfig:
+    serviceAccountRef:
+      name: KUBEFLOW-NAME-vm # {"type":"string","x-kustomize":{"partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"}]}}

--- a/kubeflow/instance/gcp_config/iam_policy.yaml
+++ b/kubeflow/instance/gcp_config/iam_policy.yaml
@@ -1,0 +1,25 @@
+# kf-admin binding in namespace kubeflow
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: KUBEFLOW-NAME-admin-wi # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"},{"name":"gcloud.core.project","value":"jlewi-dev"}]}}
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: KUBEFLOW-NAME-admin # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"},{"name":"gcloud.core.project","value":"jlewi-dev"}]}}
+  member: serviceAccount:PROJECT.svc.id.goog[kubeflow/kf-admin] # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"}]}}
+  role: roles/iam.workloadIdentityUser
+---
+# kf-admin binding in namespace istio-system
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: KUBEFLOW-NAME-admin-istio-wi # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"},{"name":"gcloud.core.project","value":"jlewi-dev"}]}}
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: KUBEFLOW-NAME-admin # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"},{"name":"gcloud.core.project","value":"jlewi-dev"}]}}
+  member: serviceAccount:PROJECT.svc.id.goog[istio-system/kf-admin] # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"}]}}
+  role: roles/iam.workloadIdentityUser

--- a/kubeflow/instance/gcp_config/kustomization.yaml
+++ b/kubeflow/instance/gcp_config/kustomization.yaml
@@ -1,0 +1,16 @@
+# This package defines the overlays of all GCP infra
+# config
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# namespace should match the project.
+# This assumes we are running CNRM in namespace mode and namespaces match project names.
+namespace: PROJECT # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"}]}}
+commonLabels:
+  kf-name: jlewi-dev
+resources:
+- ../../upstream/manifests/gcp/v2/cnrm # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcp_manifests_path","value":"../../upstream/manifests"}]}}
+- iam_policy.yaml
+patchesStrategicMerge:
+- cluster_patch.yaml
+# TODO(jlewi): Base package doesn't currently include the node pool
+# - nodepool_patch.yaml

--- a/kubeflow/instance/gcp_config/nodepool_patch.yaml
+++ b/kubeflow/instance/gcp_config/nodepool_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerNodePool
+metadata:
+  clusterName: "PROJECT/us-central1/KUBEFLOW-NAME" # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"},{"name":"name","value":"KUBEFLOW-NAME"},{"name":"location","value":"us-central1"}]}}
+  name: KUBEFLOW-NAME-cpu-pool-v1 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"}]}}
+spec:
+  nodeConfig:
+    serviceAccountRef:
+      name: KUBEFLOW-NAME-vm@PROJECT.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"},{"name":"gcloud.core.project","value":"PROJECT"}]}}
+  clusterRef:
+    name: KUBEFLOW-NAME # {"type":"string","x-kustomize":{"setter":{"name":"name","value":"KUBEFLOW-NAME"}}}

--- a/kubeflow/instance/kustomize/application/kustomization.yaml
+++ b/kubeflow/instance/kustomize/application/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../upstream/manifests/application/v3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"kustomize_manifests_path","value":"../../../upstream/manifests"}]}}

--- a/kubeflow/instance/kustomize/cert-manager-crds/kustomization.yaml
+++ b/kubeflow/instance/kustomize/cert-manager-crds/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../upstream/manifests/cert-manager/cert-manager-crds/base # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"kustomize_manifests_path","value":"../../../upstream/manifests"}]}}

--- a/kubeflow/instance/kustomize/cert-manager-kube-system-resources/kustomization.yaml
+++ b/kubeflow/instance/kustomize/cert-manager-kube-system-resources/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../upstream/manifests/cert-manager/cert-manager-kube-system-resources/base # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"kustomize_manifests_path","value":"../../../upstream/manifests"}]}}

--- a/kubeflow/instance/kustomize/cert-manager/kustomization.yaml
+++ b/kubeflow/instance/kustomize/cert-manager/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../upstream/manifests/cert-manager/cert-manager/v3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"kustomize_manifests_path","value":"../../../upstream/manifests"}]}}

--- a/kubeflow/instance/kustomize/cloud-endpoints/kustomization.yaml
+++ b/kubeflow/instance/kustomize/cloud-endpoints/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../upstream/manifests/gcp/cloud-endpoints/overlays/application # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"kustomize_manifests_path","value":"../../../upstream/manifests"}]}}
+patchesStrategicMerge:
+- service-accounts.yaml

--- a/kubeflow/instance/kustomize/cloud-endpoints/service-accounts.yaml
+++ b/kubeflow/instance/kustomize/cloud-endpoints/service-accounts.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kf-admin
+  annotations:
+    iam.gke.io/gcp-service-account: KUBEFLOW-NAME-admin@PROJECT.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"},{"name":"gcloud.core.project","value":"PROJECT"}]}}

--- a/kubeflow/instance/kustomize/iap-ingress/iap-ingress-config.yaml
+++ b/kubeflow/instance/kustomize/iap-ingress/iap-ingress-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  appName: KUBEFLOW-NAME # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"}]}}
+  hostname: KUBEFLOW-NAME.endpoints.PROJECT.cloud.goog # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"},{"name":"gcloud.core.project","value":"PROJECT"}]}}
+  ipName: KUBEFLOW-NAME-ip # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"}]}}
+  project: "PROJECT" # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"gcloud.core.project","value":"PROJECT"}}}
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: iap-ingress-config

--- a/kubeflow/instance/kustomize/iap-ingress/kustomization.yaml
+++ b/kubeflow/instance/kustomize/iap-ingress/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patchesStrategicMerge:
+- iap-ingress-config.yaml
+- service-accounts.yaml
+resources:
+- ../../../upstream/manifests/gcp/iap-ingress/v3 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"kustomize_manifests_path","value":"../../../upstream/manifests"}]}}
+- ../../../upstream/manifests/istio/iap-gateway/base # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"kustomize_manifests_path","value":"../../../upstream/manifests"}]}}

--- a/kubeflow/instance/kustomize/iap-ingress/service-accounts.yaml
+++ b/kubeflow/instance/kustomize/iap-ingress/service-accounts.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kf-admin
+  annotations:
+    iam.gke.io/gcp-service-account: KUBEFLOW-NAME-admin@PROJECT.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"},{"name":"gcloud.core.project","value":"PROJECT"}]}}

--- a/kubeflow/instance/kustomize/kubeflow-apps/default-install-config.yaml
+++ b/kubeflow/instance/kustomize/kubeflow-apps/default-install-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  profile-name: kubeflow-jlewi
+  user: jlewi@google.com
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: default-install-config

--- a/kubeflow/instance/kustomize/kubeflow-apps/kustomization.yaml
+++ b/kubeflow/instance/kustomize/kubeflow-apps/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patchesStrategicMerge:
+- profiles-config.yaml
+- default-install-config.yaml
+resources:
+- ../../../upstream/manifests/stacks/gcp # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"kustomize_manifests_path","value":"../../../upstream/manifests"}]}}

--- a/kubeflow/instance/kustomize/kubeflow-apps/profiles-config.yaml
+++ b/kubeflow/instance/kustomize/kubeflow-apps/profiles-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  admin: jlewi@google.com
+  gcp-sa: jl-stack-0409-204015-user@jlewi-dev.iam.gserviceaccount.com
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: profiles-config

--- a/kubeflow/instance/kustomize/kubeflow-apps/service-accounts.yaml
+++ b/kubeflow/instance/kustomize/kubeflow-apps/service-accounts.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kf-admin
+  annotations:
+    iam.gke.io/gcp-service-account: kf-kcc-0415-admin@PROJECT.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"kf-kcc-0415-001"},{"name":"gcloud.core.project","value":"PROJECT"}]}}

--- a/kubeflow/instance/kustomize/kubeflow-issuer/kustomization.yaml
+++ b/kubeflow/instance/kustomize/kubeflow-issuer/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../upstream/manifests/cert-manager/cert-manager/kubeflow-issuer # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"kustomize_manifests_path","value":"../../../upstream/manifests"}]}}

--- a/kubeflow/instance/kustomize/kubeflow-istio/kustomization.yaml
+++ b/kubeflow/instance/kustomize/kubeflow-istio/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../upstream/manifests/istio/istio/base # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"kustomize_manifests_path","value":"../../../upstream/manifests"}]}}

--- a/kubeflow/instance/kustomize/metacontroller/kustomization.yaml
+++ b/kubeflow/instance/kustomize/metacontroller/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../upstream/manifests/metacontroller/base # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"kustomize_manifests_path","value":"../../../upstream/manifests"}]}}

--- a/kubeflow/instance/kustomize/namespaces/kustomization.yaml
+++ b/kubeflow/instance/kustomize/namespaces/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespaces.yaml

--- a/kubeflow/instance/kustomize/namespaces/namespaces.yaml
+++ b/kubeflow/instance/kustomize/namespaces/namespaces.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow
+  labels:
+    control-plane: kubeflow
+    katib-metricscollector-injection: enabled
+---
+# TODO(jlewi): This is also defined in the cert-manager package but it doesn't get
+# created in the right order.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager

--- a/kubeflow/instance/settings.yaml
+++ b/kubeflow/instance/settings.yaml
@@ -1,0 +1,6 @@
+# Name of kubeconfig contexts for various 
+# TODO(jlewi): Add kpt setters?
+mgmt-ctxt: MANAGEMENT-CTXT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"mgmt-ctxt","value":"MANAGEMENT-CTXT"}]}}
+project: PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"}]}}
+location: us-central1 # {"type":"string","x-kustomize":{"partialSetters":[{"name":"location","value":"us-central1"}]}}
+name: KUBEFLOW-NAME # {"type":"string","x-kustomize":{"partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"}]}}

--- a/kubeflow/upstream/README.md
+++ b/kubeflow/upstream/README.md
@@ -1,0 +1,5 @@
+# Vendored packages
+
+* This directory contains vendored manifests
+* Vendored packages can be pulled in and updated using `kpt pkg`
+* You should check the vendored packages into source control.

--- a/management/Makefile
+++ b/management/Makefile
@@ -1,0 +1,62 @@
+
+# The kname of the context for the management cluster
+# The name of the context for your Kubeflow cluster
+NAME=$(shell yq r ./instance/settings.yaml name)
+MGMTCTXT=$(NAME)
+
+# The URL you want to fetch manifests from
+# TODO(jlewi): Change to kubeflow/gcp-blueprints once its checked in
+MANIFESTS_URL=https://github.com/jlewi/manifests.git/gcp/v2/management@blueprints
+
+PROJECT=$(shell yq r ./instance/settings.yaml project)
+
+# Directory where manifests should be fetched to
+MANIFESTS_DIR=./upstream/management
+
+INSTANCE_DIR=./instance
+# Print out the context
+.PHONY: echo
+echo-ctxt:
+	@echo MGMTCTXT=$(MGMTCTXT)
+
+# Get packages
+.PHONY: get-pkg
+get-pkg:
+	# TODO(jlewi): We should switch to using upstream kubeflow/manifests and pin
+	# to a specific version
+	# TODO(jlewi): We should think about how we layout packages in kubeflow/manifests so
+	# users don't end up pulling tests or other things they don't need.	
+	mkdir -p  ./upstream
+	kpt pkg get $(MANIFESTS_URL) $(MANIFESTS_DIR)
+
+.PHONY: apply
+apply: hydrate
+	anthoscli apply --project=$(PROJECT) -f .build/cluster
+
+.PHONY: hydrate
+hydrate:
+	# Delete the directory so any resources that have been removed
+	# from the manifests will be pruned
+	rm -rf .build
+	mkdir -p .build/
+	mkdir -p .build/cluster
+	kustomize build $(INSTANCE_DIR)/cluster -o .build/cluster 
+
+
+# Create a kubeconfig context for the kubeflow cluster
+.PHONE: create-ctxt
+create-ctxt:
+	PROJECT=$(shell yq r ./instance/settings.yaml project) \
+	   REGION=$(shell yq r ./instance/settings.yaml location) \
+	   NAME=$(NAME) ./hack/create_context.sh
+
+.PHONY: hydrate-kcc
+hydrate-kcc:
+	rm -rf ./.build/cnrm-install-system	
+	mkdir -p ./.build/cnrm-install-system	
+	kustomize build -o ./.build/cnrm-install-system $(INSTANCE_DIR)/cnrm-install-system
+
+.PHONY: apply-kcc
+apply-kcc: hydrate-kcc
+	kubectl --context=$(MGMTCTXT) apply -f .build/cnrm-install-system/~g_v1_namespace_cnrm-system.yaml
+	kubectl --context=$(MGMTCTXT) apply -f .build/cnrm-install-system

--- a/management/README.md
+++ b/management/README.md
@@ -1,0 +1,158 @@
+# Management Blueprint
+
+This directory contains the configuration needed to setup a management GKE cluster.
+
+This management cluster must run [Cloud Config Connector](https://cloud.google.com/config-connector/docs/overview). The management cluster is configured in namespace mode.
+Each namespace is associated with a Google Service Account which has owner permissions on 
+one or more GCP projects. You can then create GCP resources by creating CNRM resources
+in that namespace.
+
+Optionally, the cluster can be configured with [Anthos Config Managmenet](https://cloud.google.com/anthos-config-management/docs) 
+to manage GCP infrastructure using GitOps.
+
+## Install the required tools
+
+1. Install gcloud components
+
+   ```
+   gcloud components install kpt anthoscli beta
+   gcloud components update
+   ```
+
+## Setting up the management cluster
+
+
+1. Fetch the management blueprint
+
+   ```
+   kpt pkg get https://github.com/kubeflow/gcp-blueprints.git/management@master ./
+   ```
+
+1. Fetch the upstream manifests
+
+   ```
+   cd ./management
+   make get-pkg
+   ```
+
+   * TODO(jlewi): This is giving an error like the one below but this can be ignored
+
+    ```
+    kpt pkg get https://github.com/jlewi/manifests.git@blueprints ./upstream
+    fetching package / from https://github.com/jlewi/manifests to upstream/manifests
+    Error: resources must be annotated with config.kubernetes.io/index to be written to files
+    ```
+
+1. Pick a name for the management cluster
+
+   ```
+   export MGMT_NAME=<some name>
+   ```
+
+1. Pick a location for the Kubeflow deployment
+
+   ```
+   export LOCATION=<zone or region>
+   export PROJECT=<project>   
+   ```
+
+1. Set the name for the management resources in the upstream kustomize package
+
+   ```
+   kpt cfg set ./upstream name $(MGMT_NAME)   
+   ```
+
+1. Set the same names in the instance kustomize package defining patches
+
+   ```   
+   
+   kpt cfg set ./instance name $(MGMT_NAME)   
+   kpt cfg set ./instance location $(LOCATION)
+   kpt cfg set ./instance gcloud.core.project $(PROJECT)   
+   ```
+
+   * This directory defines kustomize overlays applied to `upstream/management`
+
+   * The names of the CNRM resources need to be set in both the base 
+     package and the overlays
+
+1. Hydrate and apply the manifests to create the cluster
+
+   ```
+   make apply
+   ```
+
+1. Create a kubeconfig context for the cluster
+
+   ```
+   make create-ctxt
+   ```
+
+1. Install the CNRM system components
+
+   ```
+   make install-kcc
+   ```
+
+### Setup KCC Namespace For Each Project
+
+You will configure Config Connector in [Namespaced Mode](https://cloud.google.com/config-connector/docs/concepts/installation-types#namespaced_mode). This means
+
+* There will be a separate namespace for each GCP project under management
+* CNRM resources will be created in the namespace matching the GCP project
+  in which the resource lives.
+* There will be multiple instances of the CNRM controller each managing
+  resources in a different namespace
+* Each CNRM controller can use a different K8s account which can be bound
+  through workload identity to a different GCP Service Account with permissions to manage the project
+
+For each project you want to setup follow the instructions below.
+
+1. Create a copy of the per namespace/project resources
+
+   ```
+   cp -r ./instance/install-per-project ./instance/cnrm-install-${MANAGED_PROJECT}
+   ```
+1. Set the project to be mananged
+
+   ```
+   kpt cfg set cnrm-install-${MANAGED_PROJECT} managed_project ${MANAGED_PROJECT}
+   ```
+
+1. Set the host project where kcc is running
+
+   ```
+   kpt cfg set instance/cnrm-install-${MANAGED_PROJECT} managed_gsa_name ${MANAGED_GSA_NAME}
+   kpt cfg set instance/cnrm-install-${MANAGED_PROJECT} host_project ${HOST_PROJECT}
+   kpt cfg set instance/cnrm-install-${MANAGED_PROJECt} host_id_pool ${HOST_PROJECT}.svc.id.goog
+   ```
+
+   * **MANAGED_SA_NAME** Name for the Google Service Account (GSA) to create to be used
+     with Cloud Config Connector to create resources in the managed project
+   * host_id_pool should be the workload identity pool used for the host project
+
+1. Apply this manifest to the mgmt cluster
+
+
+   ```
+   kubectl --context=$(MGMTCTXT) apply -f ./instance/cnrm-install-${PROJECT}/per-namespace-components.yaml
+   ```
+
+1. Create the GSA and workload identity binding
+
+   ```
+   anthoscli apply --project=${MANAGED_PROJECT} -f ./instance/cnrm-install-${PROJECT}/service_account.yaml
+   ```
+
+1. anthoscli doesn't support IAMPolicyMember resources yet so we use this as a workaround
+   to make the newly created GSA an owner of the hosted project
+
+   ```
+   gcloud projects add-iam-policy-binding ${MANAGED_PROJECT} \
+    --member=serviceAccount:${MANAGED_GSA_NAME}@${MANAGED_PROJECT}.iam.gserviceaccount.com  \
+    --role roles/owner
+   ```
+
+## References
+
+[CNRM Reference Documentation](https://cloud.google.com/config-connector/docs/reference/resources) 

--- a/management/hack/create_context.sh
+++ b/management/hack/create_context.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# A simple helper script to create a kubeconfig context for a particular cluster.
+#
+# usage
+# PROJECT=<PROJECT> REGION=<region> NAME=<NAME>
+#
+# TODO(jlewi): Support zonal clusters as well
+set -x 
+
+echo Checking if context ${NAME} exists 
+
+kubectl config use-context ${NAME}
+
+RESULT=$?
+
+if [ ${RESULT} -eq 0 ]; then
+echo kubeconfig context ${NAME} already exists
+exit 0
+fi
+
+set -ex
+
+# TODO test if the context already exists and if it does do nothing
+gcloud --project=${PROJECT} container clusters get-credentials \
+	   --region=${REGION} ${NAME}
+
+# Rename the context
+kubectl config rename-context $(kubectl config current-context) ${NAME}
+
+# Set the namespace to the host project
+kubectl config set-context --current --namespace=cnrm-system

--- a/management/instance/cluster/cluster.yaml
+++ b/management/instance/cluster/cluster.yaml
@@ -1,0 +1,16 @@
+# This is a patch for the management cluster.
+# It is used to define user specific values.
+apiVersion: identity.cnrm.cloud.google.com/v1alpha2
+kind: IdentityNamespace
+metadata:
+  name: default
+---
+# TODO(jlewi): Use a regional cluster? There should no longer be any cost savings to using zonal
+apiVersion: container.cnrm.cloud.google.com/v1alpha2
+kind: ContainerCluster
+metadata:
+  clusterName: "HOST_PROJECT/us-central1/MANAGEMENT-NAME" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"HOST_PROJECT"},{"name":"name","value":"MANAGEMENT-NAME"},{"name":"location","value":"us-central1"}]}}
+  name: MANAGEMENT-NAME # {"type":"string","x-kustomize":{"setter":{"name":"name","value":"MANAGEMENT-NAME"}}}
+spec:
+  # Use a regional cluster. Regional offer higher availability and the cluster management fee is the same.
+  location: us-central1 # {"type":"string","x-kustomize":{"setter":{"name":"location","value":"us-central1"}}}

--- a/management/instance/cluster/kustomization.yaml
+++ b/management/instance/cluster/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: HOST_PROJECT # {"type":"string","x-kustomize":{"setter":{"name":"gcloud.core.project","value":"HOST_PROJECT"}}}
+resources:
+- ../../upstream/management/cluster
+patchesStrategicMerge:
+- cluster.yaml
+- nodepool.yaml

--- a/management/instance/cluster/nodepool.yaml
+++ b/management/instance/cluster/nodepool.yaml
@@ -1,0 +1,5 @@
+apiVersion: container.cnrm.cloud.google.com/v1alpha2
+kind: ContainerNodePool
+metadata:
+  clusterName: "HOST_PROJECT/us-central1/MANAGEMENT-NAME" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"HOST_PROJECT"},{"name":"name","value":"MANAGEMENT-NAME"},{"name":"location","value":"us-central1"}]}}
+  name: MANAGEMENT-NAME-pool # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"project-id"},{"name":"name","value":"MANAGEMENT-NAME"},{"name":"location","value":"us-central1-f"}]}}

--- a/management/instance/cnrm-install-per-namespace/README.md
+++ b/management/instance/cnrm-install-per-namespace/README.md
@@ -1,0 +1,2 @@
+TODO(jlewi): What should we do about this directory?
+Should we make it an example template? Remove it all together from git?

--- a/management/instance/cnrm-install-per-namespace/namespace.yaml
+++ b/management/instance/cnrm-install-per-namespace/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "ns1" # {"$ref":"#/definitions/io.k8s.cli.setters.namespace"}
+  annotations:
+    cnrm.cloud.google.com/project-id: "gcp-project" # {"$ref":"#/definitions/io.k8s.cli.setters.managed-project"}
+    gke.io/cluster: gke://gcp-project/us-central1-f/management # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-cluster-annotation"}

--- a/management/instance/cnrm-install-per-namespace/per-namespace-components.yaml
+++ b/management/instance/cnrm-install-per-namespace/per-namespace-components.yaml
@@ -1,0 +1,173 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+    iam.gke.io/gcp-service-account: MANAGED-GSA-NAME@MANAGED_PROJECT.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"},{"name":"managed_gsa_name","value":"MANAGED-GSA-NAME"}]}}
+  labels:
+    cnrm.cloud.google.com/scoped-namespace: MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-controller-manager-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  namespace: cnrm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/scoped-namespace: MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-admin-binding-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  namespace: cnrm-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-admin
+subjects:
+- kind: ServiceAccount
+  name: cnrm-controller-manager-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  namespace: cnrm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/scoped-namespace: MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-manager-ns-binding-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  namespace: cnrm-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-manager-ns-role
+subjects:
+- kind: ServiceAccount
+  name: cnrm-controller-manager-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  namespace: cnrm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/scoped-namespace: MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-manager-ns-binding-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  namespace: cnrm-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-manager-ns-role
+subjects:
+- kind: ServiceAccount
+  name: cnrm-controller-manager-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  namespace: cnrm-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/scoped-namespace: MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-manager-cluster-binding-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnrm-manager-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: cnrm-controller-manager-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  namespace: cnrm-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+    prometheus.io/port: "8888"
+    prometheus.io/scrape: "true"
+  labels:
+    cnrm.cloud.google.com/monitored: "true"
+    cnrm.cloud.google.com/scoped-namespace: MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-manager-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  namespace: cnrm-system
+spec:
+  ports:
+  - name: controller-manager
+    port: 443
+  - name: metrics
+    port: 8888
+  selector:
+    cnrm.cloud.google.com/component: cnrm-controller-manager
+    cnrm.cloud.google.com/scoped-namespace: MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+    cnrm.cloud.google.com/system: "true"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    cnrm.cloud.google.com/version: 1.7.1
+  labels:
+    cnrm.cloud.google.com/component: cnrm-controller-manager
+    cnrm.cloud.google.com/scoped-namespace: MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+    cnrm.cloud.google.com/system: "true"
+  name: cnrm-controller-manager-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  namespace: cnrm-system
+spec:
+  selector:
+    matchLabels:
+      cnrm.cloud.google.com/component: cnrm-controller-manager
+      cnrm.cloud.google.com/scoped-namespace: MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+      cnrm.cloud.google.com/system: "true"
+  serviceName: cnrm-manager-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  template:
+    metadata:
+      annotations:
+        cnrm.cloud.google.com/version: 1.7.1
+      labels:
+        cnrm.cloud.google.com/component: cnrm-controller-manager
+        cnrm.cloud.google.com/scoped-namespace: MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+        cnrm.cloud.google.com/system: "true"
+    spec:
+      containers:
+      - args:
+        - --scoped-namespace=HOST_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"host_project","value":"HOST_PROJECT"}]}}
+        - --stderrthreshold=INFO
+        - --prometheus-scrape-endpoint=:8888
+        command:
+        - /configconnector/manager
+        image: gcr.io/cnrm-eap/controller:f190973
+        imagePullPolicy: Always
+        name: manager
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+      serviceAccountName: cnrm-controller-manager-MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+      terminationGracePeriodSeconds: 10

--- a/management/instance/cnrm-install-per-namespace/service_account.yaml
+++ b/management/instance/cnrm-install-per-namespace/service_account.yaml
@@ -1,0 +1,49 @@
+# Define the Google Service Account to be used with CNRM
+# in the management cluster.
+# Also define the workload identity binding.
+#
+# These resources should be created with AnthosCLI since we
+# need to bootstrap the management cluster.
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: MANAGED-GSA-NAME # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_gsa_name","value":"MANAGED-GSA-NAME"}]}}
+  namespace: "MANAGED_PROJECT" # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"managed_project","value":"MANAGED_PROJECT"}}}
+spec:
+  displayName: Service account for CNRM
+---
+# TODO(jlewi): Switch to IAMPolicyMember once anthos CLI supports that.
+apiVersion: iam.cnrm.cloud.google.com/v1alpha1
+kind: IAMPolicy
+metadata:
+  name: cnrm-system-MANAGED_PROJECT-wi # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  namespace: "MANAGED_PROJECT" # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"managed_project","value":"MANAGED_PROJECT"}}}
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1alpha1
+    kind: IAMServiceAccount
+    name: MANAGED-GSA-NAME # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_gsa_name","value":"MANAGED-GSA-NAME"}]}}
+  bindings:
+  - role: roles/iam.workloadIdentityUser
+    members:
+    # We use a partial setter for the entire workload id pool; i.e. ${PROJECT}.svc.id.goog
+    # Because in the case where the managed project and host project are the same setters
+    # for host and managed project would be the same and kpt would no longer know which field goes  where.
+    - serviceAccount:HOST_PROJECT.svc.id.goog[cnrm-system/cnrm-controller-manager-MANAGED_PROJECT] # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"host_id_pool","value":"HOST_PROJECT.svc.id.goog"},{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+---
+# Make the GCP SA a project owner
+# TODO(jlewi): AnthosCLI doesn't appear to support IAMPolicy Member yet so 
+# as a work around you will need to use gcloud
+
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: cnrm-system-MANAGED_PROJECT-owner # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}
+  namespace: "MANAGED_PROJECT" # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"managed_project","value":"MANAGED_PROJECT"}}}
+spec:
+  member: serviceAccount:MANAGED-GSA-NAME@MANAGED_PROJECT.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"},{"name":"managed_gsa_name","value":"MANAGED-GSA-NAME"}]}}
+  role: roles/owner
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: projects/MANAGED_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"managed_project","value":"MANAGED_PROJECT"}]}}

--- a/management/instance/cnrm-install-system/kustomization.yaml
+++ b/management/instance/cnrm-install-system/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../upstream/management/cnrm-install/install-system

--- a/management/instance/settings.yaml
+++ b/management/instance/settings.yaml
@@ -1,0 +1,6 @@
+# The purpose of this file is to store values in setters
+# so its easy to get them using yq for use in Make.
+# TODO(jlewi): File a feature request to have kpt list-setters return the value
+project: HOST_PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"HOST_PROJECT"}]}}
+name: MANAGEMENT-NAME # {"type":"string","x-kustomize":{"partialSetters":[{"name":"name","value":"MANAGEMENT-NAME"}]}}
+location: us-central1 # {"type":"string","x-kustomize":{"partialSetters":[{"name":"location","value":"us-central1"}]}}


### PR DESCRIPTION
* This PR contains two blueprints

  * A management blueprint to setup a management cluster running KCC
    This can be used to create GCP resources

  * A kubeflow blueprint for deploying kubeflow.
    * This currently doesn't deploy all the Kubeflow applications
      because some of the Kubeflow applications need to be updated
      to kustomize v3 so they can be incorporated into the package.

* Related to kubeflow/manifests#1063