### PR TITLE
Fix apply got secret already exists the 2nd time

### DIFF
--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -155,7 +155,7 @@ check-iap:
 # TODO(jlewi): How can we test to make sure CLIENT_ID is set so we don't create an empty secret.
 .PHONY: iap-secret
 iap-secret: check-iap
-	kubectl --context=$(KFCTXT) -n istio-system create secret generic kubeflow-oauth --from-literal=client_id=${CLIENT_ID} --from-literal=client_secret=${CLIENT_SECRET}
+	kubectl --context=$(KFCTXT) -n istio-system create secret generic kubeflow-oauth --from-literal=client_id=${CLIENT_ID} --from-literal=client_secret=${CLIENT_SECRET} --dry-run -o yaml | kubectl apply -f -
 
 .PHONY: wait-gcp
 wait-gcp:


### PR DESCRIPTION
/assign @jlewi 
When running `make apply` in kubeflow blueprint for the second time, it fails in the create IAP secret step, because the secret already exists.

This change update to use the --dry-run -o yaml | kubectl apply -f - trick to make this step idempotent.