### PR TITLE
Additional instructions and fixes for private GKE

### DIFF
--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -6,6 +6,7 @@ MGMTCTXT=$(shell yq r ./instance/settings.yaml mgmt-ctxt)
 # The name of the context for your Kubeflow cluster
 NAME=$(shell yq r ./instance/settings.yaml name)
 PROJECT=$(shell yq r ./instance/settings.yaml project)
+PRIVATE_GKE=$(shell yq r ./instance/settings.yaml gkePrivate true)
 
 KFCTXT=$(NAME)
 
@@ -26,12 +27,32 @@ BUILD_DIR=.build
 # The URL you want to fetch manifests from
 MANIFESTS_URL=https://github.com/kubeflow/manifests.git@master
 
-# Print out the context
-.PHONY: echo
-echo-ctxt:
-	@echo MGMTCTXT=$(MGMTCTXT)
-	@echo KFCTXT=$(KFCTXT)
+#***********************************************************************************************************************
+# Edit this section to set the values specific to your deployment
 
+.PHONY: set-values
+set-values:
+	kpt cfg set ./instance gke.private false
+
+	kpt cfg set ./instance mgmt-ctxt <YOUR_MANAGEMENT_CTXT>
+
+	kpt cfg set ./upstream/manifests/gcp name <YOUR_KF_NAME>
+	kpt cfg set ./upstream/manifests/gcp gcloud.core.project <PROJECT_TO_DEPLOY_IN>
+	kpt cfg set ./upstream/manifests/gcp gcloud.compute.zone <ZONE>
+	kpt cfg set ./upstream/manifests/gcp location <REGION OR ZONE>
+	kpt cfg set ./upstream/manifests/gcp log-firewalls false
+
+	kpt cfg set ./instance name <YOUR_KF_NAME>
+	kpt cfg set ./instance location <YOUR_REGION or ZONE>
+	kpt cfg set ./instance gcloud.compute.region <YOUR REGION>
+	kpt cfg set ./instance gcloud.core.project <YOUR PROJECT>
+
+#************************************************************************************************************************
+#
+# Package management
+#
+# The rules below help fetch and update packages
+#************************************************************************************************************************
 # Get packages
 .PHONY: get-pkg
 get-pkg:
@@ -40,63 +61,44 @@ get-pkg:
 	# TODO(jlewi): We should think about how we layout packages in kubeflow/manifests so
 	# users don't end up pulling tests or other things they don't need.
 	mkdir -p  ./upstream
-	kpt pkg get $(MANIFESTS_URL) $(MANIFESTS_DIR)
+	# kpt pkg get currently throws some errors due to the way our configs our structured
+	# so we need to ignore those and keep going.
+	-kpt pkg get $(MANIFESTS_URL) $(MANIFESTS_DIR)
 	rm -rf $(MANIFESTS_DIR)/tests
 	# TODO(jlewi): Package appears to cause problems for kpt. We should delete in the upstream
 	# since its not needed anymore.
 	# https://github.com/GoogleContainerTools/kpt/issues/539
 	rm -rf $(MANIFESTS_DIR)/common/ambassador
 		
-.PHONY: apply-gcp
-apply-gcp: hydrate-gcp
-	# Apply management resources
-	kubectl --context=$(MGMTCTXT) apply -f ./$(BUILD_DIR)/gcp_config
 
-.PHONY: apply-services
-apply-services: hydrate-gcp
-	# Apply management resources
-	anthoscli apply --project=$(PROJECT) -f ./instance/gcp_config/enable-services.yaml
+# Update the upstream packages
+.PHONE: update
+update:
+	rm -rf upstream
+	make get-pkg
+	make set-values
 
-.PHONY: apply-asm
-apply-asm: hydrate-asm
-	# We need to apply the CRD definitions first
-	kubectl --context=${KFCTXT} apply --recursive=true -f ./$(BUILD_DIR)/istio/Base/Base.yaml
-	kubectl --context=${KFCTXT} apply --recursive=true -f ./$(BUILD_DIR)/istio/Base
-	# TODO(jlewi): Should we use the newer version in asm/asm
-	# istioctl manifest --context=${KFCTXT} apply -f ./manifests/gcp/v2/asm/istio-operator.yaml 
-	# TODO(jlewi): Switch to anthoscli once it supports generating manifests 
-	# anthoscli apply -f ./manifests/gcp/v2/asm/istio-operator.yaml 
+#**************************************************************************************************************************
+# Hydration
+#
+# The rules in this section build hydrated manifests
+#**************************************************************************************************************************
 
-.PHONY: apply-kubeflow
-apply-kubeflow: hydrate-kubeflow
-	# Apply kubeflow apps
-	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/namespaces
-	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/kubeflow-istio
-	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/metacontroller
-	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/application
-	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/cloud-endpoints
-	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/iap-ingress
-	# Due to https://github.com/jetstack/cert-manager/issues/2208
-	# We need to skip validation on Kubernetes 1.14
-	kubectl --context=$(KFCTXT) apply --validate=false -f ./$(BUILD_DIR)/cert-manager-crds
-	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/cert-manager-kube-system-resources	
-	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/cert-manager
-	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/kubeflow-apps
-	# Create the kubeflow-issuer last to give cert-manager time deploy
-	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/kubeflow-issuer
-
-# TODO(jlewi): If we use prune does that give us a complete upgrade solution?
-# TODO(jlewi): Should we insert appropriate wait statements to wait for various services to
-# be available before continuing?
-.PHONY: apply
-apply: clean-build check-name check-iap apply-gcp wait-gcp create-ctxt apply-asm apply-kubeflow iap-secret
+# Run all the various hydration rules
+.PHONY: hydrate
+hydrate: clean-build hydrate-gcp hydrate-asm hydrate-kubeflow
+ifeq ($(PRIVATE_GKE),true)
+		make hydrate-mirror
+endif
+	# ignore error per https://github.com/kubeflow/gcp-blueprints/issues/37
+	-kpt fn run $(BUILD_DIR) 
 
 .PHONY: hydrate-gcp
 hydrate-gcp:
 	# ***********************************************************************************
 	# Hydrate cnrm
 	mkdir -p $(BUILD_DIR)/gcp_config 
-	kustomize build -o $(BUILD_DIR)/gcp_config $(GCP_CONFIG)
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/gcp_config $(GCP_CONFIG)
 
 .PHONY: hydrate-asm
 hydrate-asm:	
@@ -132,7 +134,96 @@ hydrate-kubeflow:
 	mkdir -p $(BUILD_DIR)/kubeflow-issuer
 	kustomize build --load_restrictor none -o $(BUILD_DIR)/kubeflow-issuer $(KF_DIR)/kubeflow-issuer
 
-#*****************************************************************************************
+
+# Hydrate resources to mirror images
+hydrate-mirror:
+	kfctl alpha mirror build $(MANIFESTS_DIR)/experimental/mirror-images/gcp_template.yaml -d ./instance/kustomize -V -o $(BUILD_DIR)/mirror-pipeline.yaml --gcb
+	mv cloudbuild.yaml $(BUILD_DIR)/
+
+	# Transform all the images 	
+	cp $(MANIFESTS_DIR)/gcp/v2/privateGKE/kustomize-fns/image_prefix.yaml $(BUILD_DIR)/	
+
+
+#*****************************************************************************************************
+# Apply
+#
+# Rules to apply the various manifests
+#****************************************************************************************************
+
+# Uber apply rule to invoke all dependencies
+# TODO(jlewi): If we use prune does that give us a complete upgrade solution?
+# TODO(jlewi): Should we insert appropriate wait statements to wait for various services to
+# be available before continuing?
+.PHONY: apply
+apply: clean-build check-name check-iap apply-gcp wait-gcp create-ctxt apply-asm apply-kubeflow iap-secret	
+ifeq ($(PRIVATE_GKE),true)
+	make apply-mirror
+	make apply-endpoint
+endif
+	# Kick the IAP pod because we will reset the policy and need to patch it.
+	# TODO(https://github.com/kubeflow/gcp-blueprints/issues/14)
+	kubectl --context=$(KFCTXT) -n istio-system delete pods -l service=iap-enabler
+
+
+.PHONY: apply-gcp
+apply-gcp: hydrate
+	# Apply management resources
+	kubectl --context=$(MGMTCTXT) apply -f ./$(BUILD_DIR)/gcp_config
+
+.PHONY: apply-services
+apply-services: hydrate
+	# Apply management resources
+	anthoscli apply --project=$(PROJECT) -f ./instance/gcp_config/enable-services.yaml
+
+.PHONY: apply-asm
+apply-asm: hydrate
+	# We need to apply the CRD definitions first
+	kubectl --context=${KFCTXT} apply --recursive=true -f ./$(BUILD_DIR)/istio/Base/Base.yaml
+	kubectl --context=${KFCTXT} apply --recursive=true -f ./$(BUILD_DIR)/istio/Base
+	# TODO(jlewi): Should we use the newer version in asm/asm
+	# istioctl manifest --context=${KFCTXT} apply -f ./manifests/gcp/v2/asm/istio-operator.yaml 
+	# TODO(jlewi): Switch to anthoscli once it supports generating manifests 
+	# anthoscli apply -f ./manifests/gcp/v2/asm/istio-operator.yaml 
+
+.PHONY: apply-kubeflow
+apply-kubeflow: hydrate
+	# Apply kubeflow apps
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/namespaces
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/kubeflow-istio
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/metacontroller
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/application
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/cloud-endpoints
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/iap-ingress
+	# Due to https://github.com/jetstack/cert-manager/issues/2208
+	# We need to skip validation on Kubernetes 1.14
+	kubectl --context=$(KFCTXT) apply --validate=false -f ./$(BUILD_DIR)/cert-manager-crds
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/cert-manager-kube-system-resources	
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/cert-manager
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/kubeflow-apps
+	# Create the kubeflow-issuer last to give cert-manager time deploy
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/kubeflow-issuer
+
+apply-mirror: hydrate-mirror
+	# Per https://github.com/kubeflow/gcp-blueprints/issues/36 cloud endpoints controller won't
+	# work when running on private GKE
+	# TODO(jlewi): This should be changed to kfctl once the command is baked into kfctl
+	# The path is also hardcoded for jlewi.
+	gcloud builds submit --async gs://kubeflow-examples/image-replicate/replicate-context.tar.gz --project $(PROJECT) --config $(BUILD_DIR)/cloudbuild.yaml	
+
+apply-endpoint:
+	# Per https://github.com/kubeflow/gcp-blueprints/issues/36 cloud endpoints controller won't
+	# work when running on private GKE
+	# TODO(jlewi): This should be changed to kfctl once the command is baked into kfctl
+	# The path is also hardcoded for jlewi.
+	/home/jlewi/git_cloud-endpoints-controller/controller --context=$(KFCTXT) -f $(BUILD_DIR)/iap-ingress/ctl.isla.solutions_v1_cloudendpoint_$(NAME).yaml 
+
+# Print out the context
+.PHONY: echo
+echo-ctxt:
+	@echo MGMTCTXT=$(MGMTCTXT)
+	@echo KFCTXT=$(KFCTXT)	
+
+#**************************************************************************************************
 # Hydrate ACM repos
 # These commands copy the configs to the appropriate acm repo
 acm-gcp: hydrate-gcp	
@@ -144,19 +235,17 @@ acm-kubeflow: hydrate-asm hydrate-kubeflow
 	find $(BUILD_DIR) -name "*.yaml" -not -path  "*/gcp_config/**" -exec cp {} $(ACM_KF_REPO)/ ";"
 
 #*****************************************************************************************
+#
+# Helpers
+#
+# The rules below provide various utilities and helpers to glue the steps together
+#*****************************************************************************************
 
 .PHONY: clean-build
 clean-build:
 	# Delete build because we want to prune any resources which are no longer defined in the manifests
 	rm -rf $(BUILD_DIR)/
 	mkdir -p $(BUILD_DIR)/
-
-# Hydrate all the application directories directories
-# TODO(jlewi): We can't use a kustomization file to combine the top level packages
-# because they might get vars conflicts. Also order is important when applying them.
-.PHONY: hydrate
-hydrate: clean-build hydrate-gcp hydrate-asm hydrate-kubeflow
-	
 
 # Make sure the name isn't too long.
 .PHONY: check-name

--- a/kubeflow/deploy_private.md
+++ b/kubeflow/deploy_private.md
@@ -1,0 +1,230 @@
+# Deploy Kubeflow with Private GKE
+
+These instructions explain how to deploy Kubeflow using private GKE and VPC-SC.
+
+1. Follow the blueprint instructions to setup a management cluster
+
+1. As a work around for (kubeflow/gcp-blueprints#32)[https://github.com/kubeflow/gcp-blueprints/issues/32]
+   modify the containercluster CRD schema in your management cluster to include missing fields
+
+   * See directions in that issue.
+
+1. Fetch the blueprint
+
+   ```
+   kpt pkg get https://github.com/kubeflow/gcp-blueprints.git/kubeflow@master ./${PKGDIR}
+   ```
+
+1. Change to the kubeflow directory
+
+   ```
+   cd ${PKGDIR}
+   ```
+
+1. Fetch Kubeflow manifests
+
+   ```
+   make get-pkg
+   ```
+
+1. Add the private GKE patches to your kustomization
+
+   1. Open `instance/gcp_config`
+   1. In patchesStrategicMerge add 
+
+      ```
+      - ../../upstream/manifests/gcp/v2/privateGKE/cluster-private-patch.yaml
+      ```
+
+   1. In resources add
+
+   	  ```
+   	  - ../../upstream/manifests/gcp/v2/privateGKE/
+   	  ```
+
+
+   * Do not use `kustomize edit` to perform the above actions until [kubernetes-sigs/kustomize#2310](https://github.com/kubernetes-sigs/kustomize/issues/2310) is fixed
+
+1. Open the `Makefile` and edit the `set-values` rule to invoke `kpt cfg set` with the desired values for
+   your deployment
+
+   * Change `kpt cfg set ./instance gke.private false` to `kpt cfg set ./instance gke.private true`
+   * You need to set region, location and zone because the deployment is a mix of zonal and regional resources and some which could be either
+
+### Deploy Kubeflow
+
+
+1. Configure the setters
+
+   ```
+   make set-values
+   ```
+
+1. Set environment variables with OAuth Client ID and Secret for IAP
+
+   ```
+   export CLIENT_ID=
+   export CLIENT_SECRET=
+   ```
+
+1. Deploy Kubeflow
+
+   ```
+   make apply
+   ```
+
+   * If this times out waiting for the cluster to be ready check if the reason the update failed is
+     because of [kubeflow/gcp-blueprints#34](https://github.com/kubeflow/gcp-blueprints/issues/35)
+
+   * In this case you can simply edit the Makefile and comment out the line
+
+     ```     
+	 kubectl --context=$(MGMTCTXT) wait --for=condition=Ready --timeout=600s  containercluster $(NAME)
+     ```
+
+   * Then rerun `make apply`
+
+1. TODO(jlewi): Add instructions for how to run the go binary locally to create the DNS endpoint
+   because the controller won't work.
+
+
+
+## Architectural notes
+
+* The reference architecture uses [Cloud Nat](https://cloud.google.com/nat/docs/overview) to allow outbound
+  internet access from node even though they don't have public IPs.
+
+  * Outbound traffic can be restricted using firewall rules
+
+  * Outbound internet access is needed to download the JWKs keys used to verify JWTs attached by IAP
+
+  * If you want to completely disable all outbound internet access you will have to find some alternative solution
+    to keep the JWKs in sync with your ISTIO policy
+
+
+## Troubleshooting
+
+* Cluster is stuck in provisioning state
+
+  * Use the UI or gcloud to figure out what state the cluster is stuck in
+  * If you use gcloud you need to look at the operation e.g.
+
+    
+    1. Find the operations
+    
+       ```
+       gcloud --project=${PROJECT} container operations list
+       ```
+
+    1. Get operation details
+
+	   ```
+       gcloud --project=${PROJECT} container operations describe --region=${REGION} ${OPERATION}
+       ```
+
+* Cluster health checks are failing.
+
+   * This is usually because the firewall rules allowing the GKE health checks are not configured correctly
+
+   * A good place to start is verifying they were created correctly
+
+     ```
+     kubectl --context=${MGMTCTXT} describe computefirewall
+     ```
+
+   * Turn on firewall rule logging to see what traffic is being blocked
+
+     ```
+     kpt cfg set ./upstream/manifests/gcp/v2/privateGKE/ log-firewalls true
+     make apply
+     ```
+
+   * To look for traffic blocked by firewall rules in stackdriver use a filter like the following
+
+      ```
+
+	  logName: "projects/${PROJECT}/logs/compute.googleapis.com%2Ffirewall" 
+ 	  jsonPayload.disposition = "DENIED"
+      ```
+
+      * **Logging must be enabled** on your firewall rules. You can enable it by using a kpt setter
+
+        ```
+        kpt cfg set ./upstream/manifests/gcp/v2/privateGKE/ log-firewalls true 
+        ```
+
+      * Change project to your project
+
+      * Then look at the fields `jsonPayload.connection` this will tell you source and destination ips
+      * Based on the IPs try to figure out where the traffic is coming from (e.g. node to master) and
+        then match to appropriate firewall rules
+
+      * For example
+
+         ```
+          connection: {
+		   dest_ip: "172.16.0.34"    
+		   dest_port: 443    
+		   protocol: 6    
+		   src_ip: "10.10.10.31"    
+		   src_port: 60556    
+		  }
+		  disposition: "DENIED" 
+         ```
+
+         * The destination IP in this case is for a GKE master so the firewall rules are not configured to correctly allow
+           traffic to the master.
+
+
+* Common cause for networking related issue is is that some of the network resources (e.g. the Network, Routes, Firewall Rules, etc... ) don't get created
+
+     * This could be because a reference is incorrect (e.g. firewall rules reference the wrong network)
+
+     * You can sanity check resources by doing kubectl describe and looking for errors.
+
+       * [kubeflow/gcp-blueprints#38](https://github.com/kubeflow/gcp-blueprints/issues/38) is tracking
+          tools to automate this
+
+* GCR images can't be pulled
+
+  * This likely indicates an issue with access to private GCR; this could be an issue with
+
+    * DNS configurations - Check that the `DNSRecordSet` and `DNSManagedZone` CNRM resources are in a ready state
+    * Routes - Ensure any default route to the internet has a larger value for the priority 
+        then any routes to private GCP APIs so that the private routes match first.
+
+        * If image pull errors show IP addresses not the restricted.googleapis.com VIP then you have
+          an issue with networking
+
+    * Firewall rules
+
+* Access to whitelisted (non Google) sites is blocked
+
+  * The configuration uses CloudNat to allow selective access to sites
+
+    * In addition to allowing IAP, this allows sites like GitHub to be whitelisted.
+
+  * In order for CloudNat to work you need
+
+    * A default route to the internet
+    * Firewall rules to allow egress traffic to whitelisted sites
+
+      * These rules need to be higher priority then the deny all firewall egress rules.
+
+### Kubernetes Webhooks are blocked by firewall rules
+
+A common failure mode is that webhooks for custom resources are blocked by default firewall rules.
+As explained in the [GKE Docs](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules) only connections from master to ports 443 and 10250
+are allowed by default. If you have a webhook serving on a different port
+you will need to add an explict ingress firewall rule to allow that port to be accessed.
+
+These errors usually manifest as failures to create custom resources that depend on webhooks. An example
+error is
+
+```
+Error from server (InternalError): error when creating ".build/kubeflow-apps/cert-manager.io_v1alpha2_certificate_admission-webhook-cert.yaml": Internal error occurred: failed calling webhook "webhook.cert-manager.io": the server is currently unable to handle the request
+```
+
+# References
+
+[Blog Post Private GKE Clusters](https://medium.com/google-cloud/completely-private-gke-clusters-with-no-internet-connectivity-945fffae1ccd)

--- a/kubeflow/instance/gcp_config/enable-services.yaml
+++ b/kubeflow/instance/gcp_config/enable-services.yaml
@@ -1,3 +1,5 @@
+# TODO(jlewi): I think we can delete this because we shouldbe using CNRM to enable services now
+# and this should be in the base package.
 # GKE
 apiVersion: cnrm.cloud.google.com/v1alpha1
 kind: CloudService

--- a/kubeflow/instance/settings.yaml
+++ b/kubeflow/instance/settings.yaml
@@ -4,3 +4,4 @@ mgmt-ctxt: MANAGEMENT-CTXT # {"type":"string","x-kustomize":{"partialSetters":[{
 project: PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"}]}}
 location: us-central1 # {"type":"string","x-kustomize":{"partialSetters":[{"name":"location","value":"us-central1"}]}}
 name: KUBEFLOW-NAME # {"type":"string","x-kustomize":{"partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"}]}}
+gkePrivate: false # {"type":"bool","x-kustomize":{"partialSetters":[{"name":"gke.private","value": "false"}]}}


### PR DESCRIPTION
* Tracking issue #33

* The rules "apply-asm", "apply-gcp", "apply-kubeflow" should all
  depend on the hydrate rule; not component specific hydration rules.

  * This is because we might want to apply kpt functions as part of hydration
    so these commands would be added to the hydration rule and need
    to be called before calling the respective apply commands.

* Delete enable-services.yaml we no longer use it; we will use CNRM.

* A bunch of improvements to the Makefile

  * Organize it in hydrate and apply sections
  * Add a set-values stanza to run all the kpt cfg set commands
  * Use if statements to deal with differences e.g. private vs.
    non-private deployments
     * Need to add this for ASM deployments.