### PR TITLE
Add kpt setters for default profile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,13 @@ clean-for-pr:
 	rm -rf kubeflow/upstream/manifests
 	rm -rf management/upstream/management
 	
-
 	kpt cfg set ./kubeflow/instance name KUBEFLOW-NAME
 	kpt cfg set ./kubeflow/instance gcloud.core.project PROJECT
 	kpt cfg set ./kubeflow/instance mgmt-ctxt MANAGEMENT-CTXT
+	kpt cfg set ./kubeflow/instance email EMAIL
+	kpt cfg set ./kubeflow/instance location LOCATION
+	kpt cfg set ./kubeflow/instance gcloud.compute.region REGION
+	kpt cfg set ./kubeflow/instance gcloud.compute.zone ZONE
 
 	kpt cfg set ./management/instance name MANAGEMENT-NAME
 	kpt cfg set ./management/instance gcloud.core.project HOST_PROJECT

--- a/kubeflow/instance/gcp_config/cluster_patch.yaml
+++ b/kubeflow/instance/gcp_config/cluster_patch.yaml
@@ -2,12 +2,12 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerCluster
 metadata:
-  clusterName: "PROJECT/us-central1/KUBEFLOW-NAME" # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"},{"name":"name","value":"KUBEFLOW-NAME"},{"name":"location","value":"us-central1"}]}}
+  clusterName: "PROJECT/LOCATION/KUBEFLOW-NAME" # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"},{"name":"name","value":"KUBEFLOW-NAME"},{"name":"location","value":"LOCATION"}]}}
   labels:
-    mesh_id: "PROJECT_us-central1_KUBEFLOW-NAME" # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"},{"name":"name","value":"KUBEFLOW-NAME"},{"name":"location","value":"us-central1"}]}}
+    mesh_id: "PROJECT_LOCATION_KUBEFLOW-NAME" # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"},{"name":"name","value":"KUBEFLOW-NAME"},{"name":"location","value":"LOCATION"}]}}
   name: KUBEFLOW-NAME # {"type":"string","x-kustomize":{"setter":{"name":"name","value":"KUBEFLOW-NAME"}}}
 spec:
-  location: us-central1 # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"location","value":"us-central1"}}}
+  location: LOCATION # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"location","value":"LOCATION"}}}
   workloadIdentityConfig:
     identityNamespace: PROJECT.svc.id.goog # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"}]}}
   nodeConfig:

--- a/kubeflow/instance/gcp_config/nodepool_patch.yaml
+++ b/kubeflow/instance/gcp_config/nodepool_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerNodePool
 metadata:
-  clusterName: "PROJECT/us-central1/KUBEFLOW-NAME" # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"},{"name":"name","value":"KUBEFLOW-NAME"},{"name":"location","value":"us-central1"}]}}
+  clusterName: "PROJECT/LOCATION/KUBEFLOW-NAME" # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"},{"name":"name","value":"KUBEFLOW-NAME"},{"name":"location","value":"LOCATION"}]}}
   name: KUBEFLOW-NAME-cpu-pool-v1 # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"}]}}
 spec:
   nodeConfig:

--- a/kubeflow/instance/kustomize/kubeflow-apps/default-install-config.yaml
+++ b/kubeflow/instance/kustomize/kubeflow-apps/default-install-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-  profile-name: kubeflow-jlewi
-  user: jlewi@google.com
+  profile-name: default-profile
+  user: EMAIL # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"email","value":"EMAIL"}]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/kubeflow/instance/kustomize/kubeflow-apps/profiles-config.yaml
+++ b/kubeflow/instance/kustomize/kubeflow-apps/profiles-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-  admin: jlewi@google.com
-  gcp-sa: jl-stack-0409-204015-user@jlewi-dev.iam.gserviceaccount.com
+  admin: EMAIL # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"email","value":"EMAIL"},{"name":"gcloud.core.project","value":"PROJECT"}]}}
+  gcp-sa: KUBEFLOW-NAME-user@PROJECT.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"},{"name":"gcloud.core.project","value":"PROJECT"}]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/kubeflow/instance/settings.yaml
+++ b/kubeflow/instance/settings.yaml
@@ -2,6 +2,6 @@
 # TODO(jlewi): Add kpt setters?
 mgmt-ctxt: MANAGEMENT-CTXT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"mgmt-ctxt","value":"MANAGEMENT-CTXT"}]}}
 project: PROJECT # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"PROJECT"}]}}
-location: us-central1 # {"type":"string","x-kustomize":{"partialSetters":[{"name":"location","value":"us-central1"}]}}
+location: LOCATION # {"type":"string","x-kustomize":{"partialSetters":[{"name":"location","value":"LOCATION"}]}}
 name: KUBEFLOW-NAME # {"type":"string","x-kustomize":{"partialSetters":[{"name":"name","value":"KUBEFLOW-NAME"}]}}
 gkePrivate: false # {"type":"bool","x-kustomize":{"partialSetters":[{"name":"gke.private","value": "false"}]}}


### PR DESCRIPTION
* We need kpt setters in order to properly set the email for the default
  profile created.

* Also rerun `clean-for-pr` to clear some of the default values.