### PR TITLE
Automated cherry pick of #84: Install knative-serving into its own namespace. #87: Need to create the knative-serving namespace in the proper Cherry pick of #84 #87 on v1.1-branch. #84: Install knative-serving into its own namespace. #87: Need to create the knative-serving namespace in the proper

### DIFF
--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -120,6 +120,10 @@ hydrate-kubeflow:
 
 	mkdir -p $(BUILD_DIR)/application
 	kustomize build --load_restrictor none -o $(BUILD_DIR)/application $(KF_DIR)/application
+
+	mkdir -p $(BUILD_DIR)/knative
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/knative $(KF_DIR)/knative
+
 	mkdir -p $(BUILD_DIR)/cert-manager
 	kustomize build --load_restrictor none -o $(BUILD_DIR)/cert-manager $(KF_DIR)/cert-manager
 	mkdir -p $(BUILD_DIR)/cert-manager-crds
@@ -188,7 +192,7 @@ apply-asm: hydrate
 	# TODO(jlewi): Should we use the newer version in asm/asm
 	# istioctl manifest --context=${KFCTXT} apply -f ./manifests/gcp/v2/asm/istio-operator.yaml
 	# TODO(jlewi): Switch to anthoscli once it supports generating manifests
-	# anthoscli apply -f ./manifests/gcp/v2/asm/istio-operator.yaml
+	# anthoscli apply -f ./manifests/gcp/v2/asm/istio-operator.yaml	
 
 .PHONY: apply-kubeflow
 apply-kubeflow: hydrate
@@ -198,7 +202,8 @@ apply-kubeflow: hydrate
 	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/metacontroller
 	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/application
 	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/cloud-endpoints
-	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/iap-ingress
+	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/iap-ingress	
+	kubectl --context=${KFCTXT} apply --recursive=true -f ./$(BUILD_DIR)/knative
 	# Due to https://github.com/jetstack/cert-manager/issues/2208
 	# We need to skip validation on Kubernetes 1.14
 	kubectl --context=$(KFCTXT) apply --validate=false -f ./$(BUILD_DIR)/cert-manager-crds

--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -203,7 +203,11 @@ apply-kubeflow: hydrate
 	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/application
 	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/cloud-endpoints
 	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/iap-ingress	
+
+	# Apply the namespace first
+	kubectl --context=${KFCTXT} apply -f ./$(BUILD_DIR)/knative/~g_v1_namespace_knative-serving.yaml 
 	kubectl --context=${KFCTXT} apply --recursive=true -f ./$(BUILD_DIR)/knative
+
 	# Due to https://github.com/jetstack/cert-manager/issues/2208
 	# We need to skip validation on Kubernetes 1.14
 	kubectl --context=$(KFCTXT) apply --validate=false -f ./$(BUILD_DIR)/cert-manager-crds

--- a/kubeflow/instance/kustomize/knative/kustomization.yaml
+++ b/kubeflow/instance/kustomize/knative/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../upstream/manifests/knative/installs/generic # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"kustomize_manifests_path","value":"../../../upstream/manifests"}]}}


### PR DESCRIPTION
Related to #74 