### PR TITLE
Remove deprecated --project flag from anthoscli

### DIFF
--- a/management/Makefile
+++ b/management/Makefile
@@ -37,7 +37,7 @@ get-pkg:
 # Create the cluster
 .PHONY: apply
 apply: hydrate
-	anthoscli apply --project=$(PROJECT) -f .build/cluster
+	anthoscli apply -f .build/cluster
 
 .PHONY: hydrate
 hydrate: validate-values


### PR DESCRIPTION
Flag --project has been deprecated, GCE project flag is unused and deprecated