### PR TITLE
Explicitly disable container native load balancing (neg) 

### DIFF
--- a/kubeflow/instance/kustomize/iap-ingress/kustomization.yaml
+++ b/kubeflow/instance/kustomize/iap-ingress/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 patchesStrategicMerge:
 - iap-ingress-config.yaml
 - service-accounts.yaml
+- service.yaml
 resources:
 - ../../../upstream/manifests/gcp/iap-ingress/v3 # {"$kpt-set":"gcp-iap-ingress-v3"}
 - ../../../upstream/manifests/istio/iap-gateway/base # {"$kpt-set":"istio-iap-gateway-base"}

--- a/kubeflow/instance/kustomize/iap-ingress/kustomization.yaml
+++ b/kubeflow/instance/kustomize/iap-ingress/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 patchesStrategicMerge:
 - iap-ingress-config.yaml
 - service-accounts.yaml
+# Explicitly disable container native load balancing
+# See: https://github.com/kubeflow/gcp-blueprints/pull/141
 - service.yaml
 resources:
 - ../../../upstream/manifests/gcp/iap-ingress/v3 # {"$kpt-set":"gcp-iap-ingress-v3"}

--- a/kubeflow/instance/kustomize/iap-ingress/service.yaml
+++ b/kubeflow/instance/kustomize/iap-ingress/service.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-ingressgateway
+  annotations:
+    cloud.google.com/neg: '{"ingress": false}'


### PR DESCRIPTION
# Problem

`envoy-ingress` backend services unhealthy when installing Kubeflow on GKE version `1.17.9-gke.1504`

# Solution

Add the `cloud.google.com/neg: '{"ingress": false}'` annotation to `istio-ingressgateway` to disable **container-native load balancing** (neg) which is enabled by default for GKE clusters >= 1.17 ( https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing#using )

