### PR TITLE
Revert "Explicitly disable container native load balancing (neg) "

### DIFF
--- a/kubeflow/instance/kustomize/iap-ingress/kustomization.yaml
+++ b/kubeflow/instance/kustomize/iap-ingress/kustomization.yaml
@@ -3,9 +3,6 @@ kind: Kustomization
 patchesStrategicMerge:
 - iap-ingress-config.yaml
 - service-accounts.yaml
-# Explicitly disable container native load balancing
-# See: https://github.com/kubeflow/gcp-blueprints/pull/141
-- service.yaml
 resources:
 - ../../../upstream/manifests/gcp/iap-ingress/v3 # {"$kpt-set":"gcp-iap-ingress-v3"}
 - ../../../upstream/manifests/istio/iap-gateway/base # {"$kpt-set":"istio-iap-gateway-base"}

--- a/kubeflow/instance/kustomize/iap-ingress/service.yaml
+++ b/kubeflow/instance/kustomize/iap-ingress/service.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: istio-ingressgateway
-  annotations:
-    cloud.google.com/neg: '{"ingress": false}'


### PR DESCRIPTION
Reverts kubeflow/gcp-blueprints#141

I don't think this annotation fixed the problem per investigation in https://github.com/kubeflow/gcp-blueprints/issues/160

Part of https://github.com/kubeflow/gcp-blueprints/issues/160

/assign @jlewi