### PR TITLE
feat: kick backend-updater after apply

### DIFF
--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -158,6 +158,9 @@ endif
 	# Kick the IAP pod because we will reset the policy and need to patch it.
 	# TODO(https://github.com/kubeflow/gcp-blueprints/issues/14)
 	kubectl --context=$(KFCTXT) -n istio-system delete pods -l service=iap-enabler
+	# Kick the backend updater pod, because information might be outdated after the apply.
+	# https://github.com/kubeflow/gcp-blueprints/issues/160
+	kubectl --context=$(KFCTXT) -n istio-system delete pods -l service=backend-updater
 
 
 .PHONY: apply-gcp


### PR DESCRIPTION
Fixes https://github.com/kubeflow/gcp-blueprints/issues/160

This should reduce chances of seeing https://github.com/kubeflow/gcp-blueprints/issues/160