### PR TITLE
feat: revert to kf 1.1 installation UX for kubeflow package

### DIFF
--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -5,10 +5,8 @@ MGMTCTXT=$(shell yq r ./instance/Kptfile 'openAPI.definitions."io.k8s.cli.setter
 # The name of the context for your Kubeflow cluster
 NAME=$(shell yq r ./instance/Kptfile 'openAPI.definitions."io.k8s.cli.setters.name".x-k8s-cli.setter.value')
 LOCATION=$(shell yq r ./instance/Kptfile 'openAPI.definitions."io.k8s.cli.setters.location".x-k8s-cli.setter.value')
-ZONE=$(shell yq r ./instance/Kptfile 'openAPI.definitions."io.k8s.cli.setters.gcloud.compute.zone".x-k8s-cli.setter.value')
 PROJECT=$(shell yq r ./instance/Kptfile 'openAPI.definitions."io.k8s.cli.setters.gcloud.core.project".x-k8s-cli.setter.value')
 PRIVATE_GKE=$(shell yq r ./instance/Kptfile 'openAPI.definitions."io.k8s.cli.setters.gke.private".x-k8s-cli.setter.value')
-FIREWALL_LOGS=$(shell yq r ./instance/Kptfile 'openAPI.definitions."io.k8s.cli.setters.log-firewalls".x-k8s-cli.setter.value')
 
 KFCTXT=$(NAME)
 
@@ -39,6 +37,28 @@ ifeq ($(shell test "$(MGMTCTXT)" =  MANAGEMENT-CTXT  -o  \
                    "$(PROJECT)"  =  PROJECT  &&  printf "true"), true)
 	$(error Either of MGMTCTXT, NAME, ZONE, LOCATION, PROJECT values not set)
 endif
+#***********************************************************************************************************************
+# Edit this section to set the values specific to your deployment
+
+.PHONY: set-values
+set-values:
+	kpt cfg set ./instance gke.private false
+
+	kpt cfg set ./instance mgmt-ctxt <YOUR_MANAGEMENT_CTXT>
+
+	kpt cfg set ./upstream/manifests/gcp name <YOUR_KF_NAME>
+	kpt cfg set ./upstream/manifests/gcp gcloud.core.project <PROJECT_TO_DEPLOY_IN>
+	kpt cfg set ./upstream/manifests/gcp gcloud.compute.zone <ZONE>
+	kpt cfg set ./upstream/manifests/gcp location <REGION OR ZONE>
+	kpt cfg set ./upstream/manifests/gcp log-firewalls false
+
+	kpt cfg set ./upstream/manifests/stacks/gcp name <YOUR_KF_NAME>
+	kpt cfg set ./upstream/manifests/stacks/gcp gcloud.core.project <PROJECT_TO_DEPLOY_IN>
+
+	kpt cfg set ./instance name <YOUR_KF_NAME>
+	kpt cfg set ./instance location <YOUR_REGION or ZONE>
+	kpt cfg set ./instance gcloud.core.project <YOUR PROJECT>
+	kpt cfg set ./instance email <YOUR_EMAIL_ADDRESS>
 
 #************************************************************************************************************************
 #
@@ -67,6 +87,7 @@ get-pkg:
 update:
 	rm -rf upstream
 	make get-pkg
+	make set-values
 
 #**************************************************************************************************************************
 # Hydration
@@ -272,17 +293,7 @@ acm-kubeflow: hydrate-asm hydrate-kubeflow
 #*****************************************************************************************
 
 .PHONY: clean-build
-clean-build: validate-values
-	# Dedupe values to ./upstream/manifest
-	kpt cfg set ./upstream/manifests/gcp name $(NAME)
-	kpt cfg set ./upstream/manifests/gcp gcloud.core.project $(PROJECT)
-	kpt cfg set ./upstream/manifests/gcp gcloud.compute.zone $(ZONE)
-	kpt cfg set ./upstream/manifests/gcp location $(LOCATION)
-	kpt cfg set ./upstream/manifests/gcp log-firewalls $(FIREWALL_LOGS)
-
-	kpt cfg set ./upstream/manifests/stacks/gcp name $(NAME)
-	kpt cfg set ./upstream/manifests/stacks/gcp gcloud.core.project $(PROJECT)
-
+clean-build:
 	# Delete build because we want to prune any resources which are no longer defined in the manifests
 	rm -rf $(BUILD_DIR)/
 	mkdir -p $(BUILD_DIR)/
@@ -308,7 +319,7 @@ wait-gcp:
 
 # Create a kubeconfig context for the kubeflow cluster
 .PHONY: create-ctxt
-create-ctxt: validate-values
+create-ctxt:
 	PROJECT=$(PROJECT) \
 	   REGION=$(LOCATION) \
 	   NAME=$(NAME) ./hack/create_context.sh

--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -36,6 +36,11 @@ ifeq ($(shell test "$(MGMTCTXT)" =  MANAGEMENT-CTXT  -o  \
                    "$(PROJECT)"  =  PROJECT  &&  printf "true"), true)
 	$(error Either of MGMTCTXT, NAME, LOCATION, PROJECT values not set)
 endif
+# Validate cluster name <= 18 characters
+ifeq ($(shell test $(shell printf "$(NAME)" | wc -c) -gt 18 && printf "true"), true)
+	$(error Kubeflow cluster name cannot exceed 18 characthers in length. Got: "$(NAME)")
+endif
+
 #***********************************************************************************************************************
 # Edit this section to set the values specific to your deployment
 
@@ -98,7 +103,7 @@ update:
 
 # Run all the various hydration rules
 .PHONY: hydrate
-hydrate: clean-build hydrate-gcp hydrate-asm hydrate-kubeflow
+hydrate: clean-build validate-values hydrate-gcp hydrate-asm hydrate-kubeflow
 ifeq ($(PRIVATE_GKE),true)
 		make hydrate-mirror
 endif

--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -32,10 +32,9 @@ MANIFESTS_URL?=https://github.com/kubeflow/manifests.git@v1.2-branch
 validate-values:
 ifeq ($(shell test "$(MGMTCTXT)" =  MANAGEMENT-CTXT  -o  \
                    "$(NAME)"     =  KUBEFLOW-NAME  -o  \
-                   "$(ZONE)"     =  ZONE -o \
                    "$(LOCATION)" =  LOCATION  -o  \
                    "$(PROJECT)"  =  PROJECT  &&  printf "true"), true)
-	$(error Either of MGMTCTXT, NAME, ZONE, LOCATION, PROJECT values not set)
+	$(error Either of MGMTCTXT, NAME, LOCATION, PROJECT values not set)
 endif
 #***********************************************************************************************************************
 # Edit this section to set the values specific to your deployment
@@ -72,14 +71,16 @@ set-values:
 .PHONY: get-pkg
 get-pkg:
 	mkdir -p  ./upstream
-	# kpt pkg get currently throws some errors due to the way our configs our structured
-	# so we need to ignore those and keep going.
-	-kpt pkg get $(MANIFESTS_URL) $(MANIFESTS_DIR)
+	# kpt pkg get auto-set currently throws some errors due to the way our configs
+	# our structured, so we need to disable auto-set.
+	kpt pkg get --auto-set=false $(MANIFESTS_URL) $(MANIFESTS_DIR)
 	rm -rf $(MANIFESTS_DIR)/tests
 	# TODO(jlewi): Package appears to cause problems for kpt. We should delete in the upstream
 	# since its not needed anymore.
 	# https://github.com/GoogleContainerTools/kpt/issues/539
 	rm -rf $(MANIFESTS_DIR)/common/ambassador
+	rm -rf $(MANIFESTS_DIR)/stacks/ibm
+	rm -rf $(MANIFESTS_DIR)/stacks/openshift
 
 
 # Update the upstream packages

--- a/kubeflow/instance/Kptfile
+++ b/kubeflow/instance/Kptfile
@@ -37,11 +37,6 @@ openAPI:
         setter:
           name: location
           value: LOCATION
-    io.k8s.cli.setters.gcloud.compute.zone:
-      x-k8s-cli:
-        setter:
-          name: gcloud.compute.zone
-          value: ZONE
     io.k8s.cli.setters.mgmt-ctxt:
       x-k8s-cli:
         setter:
@@ -168,11 +163,6 @@ openAPI:
       x-k8s-cli:
         setter:
           name: gke.private
-          value: "false"
-    io.k8s.cli.setters.log-firewalls:
-      x-k8s-cli:
-        setter:
-          name: log-firewalls
           value: "false"
     io.k8s.cli.setters.email:
       x-k8s-cli:

--- a/tests/validate_test.go
+++ b/tests/validate_test.go
@@ -1,12 +1,13 @@
 package tests
 
 import (
-	shutil "github.com/termie/go-shutil"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"testing"
+
+	shutil "github.com/termie/go-shutil"
 )
 
 // TestHydrate verifies we can properly hydrate the config
@@ -43,27 +44,34 @@ func TestHydrate(t *testing.T) {
 	}
 
 	setValues := func(vars map[string]string, subDir string) {
-			for k, v := range vars {
-				cmd := exec.Command("kpt", "cfg", "set", subDir, k, v)
-				cmd.Dir = target
-				out, err := cmd.CombinedOutput()
+		for k, v := range vars {
+			cmd := exec.Command("kpt", "cfg", "set", subDir, k, v)
+			cmd.Dir = target
+			out, err := cmd.CombinedOutput()
 
-				t.Logf("Run %v:\n%v", cmd, string(out))
+			t.Logf("Run %v:\n%v", cmd, string(out))
 
-				if err != nil {
-					t.Fatalf("%v failed; error %v", cmd, err)
-				}
+			if err != nil {
+				t.Fatalf("%v failed; error %v", cmd, err)
 			}
+		}
 	}
-	instanceVars := map[string]string {
-		"mgmt-ctxt": "mgmt-ctxt",
-		"name": "kf-test",
-		"gcloud.compute.zone": "us-east1-d",
+	instanceVars := map[string]string{
+		"mgmt-ctxt":           "mgmt-ctxt",
+		"name":                "kf-test",
 		"gcloud.core.project": "kubeflow-ci-deployment",
-		"location": "us-east1",
-		"email": "user@gmail.com",
+		"location":            "us-east1",
+		"email":               "user@gmail.com",
 	}
 	setValues(instanceVars, "instance")
+
+	upstreamVars := map[string]string{
+		"name":                "kf-test",
+		"gcloud.core.project": "kubeflow-ci-deployment",
+		"gcloud.compute.zone": "us-east1-d",
+		"location":            "us-east1",
+	}
+	setValues(upstreamVars, "upstream/manifests/gcp")
 
 	cmd = exec.Command("make", "hydrate")
 	cmd.Dir = target


### PR DESCRIPTION
Temporary workaround because of https://github.com/kubeflow/gcp-blueprints/issues/158#issuecomment-731028479

/cc @subodh101 @jlewi 

The goal of this change is that, users can upgrade Kubeflow v1.1 to v1.2 by just
```bash
make update set-values apply
```

So we shouldn't depend on some additional setters not present in Kubeflow v1.1 `instance` folder.

Before the next upgrade, we should be able to use the ideal UX of https://github.com/kubeflow/gcp-blueprints/issues/158#issuecomment-729495722