### PR TITLE
fix: kustomize 3.8 compatibility

### DIFF
--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -215,7 +215,11 @@ apply-kubeflow: hydrate
 	kubectl --context=$(KFCTXT) apply -f ./$(BUILD_DIR)/iap-ingress
 
 	# Apply the namespace first
-	kubectl --context=${KFCTXT} apply -f ./$(BUILD_DIR)/knative/~g_v1_namespace_knative-serving.yaml
+	#
+	# Note, insert a * before v1_namespace, because different versions of
+	# kustomize may generate slightly different file names:
+	# https://github.com/kubeflow/gcp-blueprints/issues/164.
+	kubectl --context=${KFCTXT} apply -f ./$(BUILD_DIR)/knative/*v1_namespace_knative-serving.yaml
 	kubectl --context=${KFCTXT} apply --recursive=true -f ./$(BUILD_DIR)/knative
 
 	# Due to https://github.com/jetstack/cert-manager/issues/2208

--- a/packages/management/Makefile
+++ b/packages/management/Makefile
@@ -93,7 +93,7 @@ apply-kcc:
 	anthoscli apply -f $(BUILD_DIR)/cnrm-install-iam
 	# Deploy Config Connector to the cluster
 	# Apply and wait for the CRDs and namespaces first
-	for resource in $$(find $(BUILD_DIR)/cnrm-install-system -name '~g_v1_namespace_*.yaml' -o -name '*_customresourcedefinition_*.yaml'); \
+	for resource in $$(find $(BUILD_DIR)/cnrm-install-system -name 'v1_namespace_*.yaml' -o -name '*_customresourcedefinition_*.yaml'); \
 	do \
 		kubectl $(CTXT_ARG) apply -f $$resource; \
 	done

--- a/packages/management/Makefile
+++ b/packages/management/Makefile
@@ -93,7 +93,7 @@ apply-kcc:
 	anthoscli apply -f $(BUILD_DIR)/cnrm-install-iam
 	# Deploy Config Connector to the cluster
 	# Apply and wait for the CRDs and namespaces first
-	for resource in $$(find $(BUILD_DIR)/cnrm-install-system -name 'v1_namespace_*.yaml' -o -name '*_customresourcedefinition_*.yaml'); \
+	for resource in $$(find $(BUILD_DIR)/cnrm-install-system -name '*v1_namespace_*.yaml' -o -name '*_customresourcedefinition_*.yaml'); \
 	do \
 		kubectl $(CTXT_ARG) apply -f $$resource; \
 	done


### PR DESCRIPTION
Fixes https://github.com/kubeflow/gcp-blueprints/issues/164

Upstream issue has been resolved: https://github.com/kubeflow/manifests/pull/1610
So we should be compatible with latest kustomize, right now kustomize 3.8