### PR TITLE
(cluster) Use STABLE release channel, change machineType to e2-standard-8. Fix #213, Fix #214

### DIFF
--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -215,8 +215,8 @@ iap-secret: check-iap
 .PHONY: check-iap
 check-iap:
 	./hack/check_oauth_secret.sh
-	# Delete gcp resources
-
+	
+# Delete gcp resources
 .PHONY: delete-gcp
 delete-gcp:
 	kubectl	--context=$(MGMTCTXT) delete -f $(BUILD_DIR)/gcp_config

--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -45,12 +45,16 @@ endif
 check-name:
 	PROJECT=$(PROJECT) NAME=$(NAME) ./hack/check_domain_length.sh
 
-.PHONY: apply-kubeflow
-apply-kubeflow: validate-values check-name 
-	# GCP Resources
+.PHONY: apply-cnrm
+apply-cnrm:
 	rm -rf $(BUILD_DIR)/gcp_config && mkdir -p $(BUILD_DIR)/gcp_config
 	kustomize build --load-restrictor LoadRestrictionsNone -o $(BUILD_DIR)/gcp_config ./common/cnrm
 	kubectl --context=$(MGMTCTXT) apply -f ./$(BUILD_DIR)/gcp_config
+
+.PHONY: apply-kubeflow
+apply-kubeflow: validate-values check-name 
+	# GCP Resources
+	$(MAKE) apply-cnrm
 
 	# Wait for GCP Resources to finish.
 	$(MAKE) -C common/cnrm wait-gcp
@@ -211,4 +215,8 @@ iap-secret: check-iap
 .PHONY: check-iap
 check-iap:
 	./hack/check_oauth_secret.sh
-	
+	# Delete gcp resources
+
+.PHONY: delete-gcp
+delete-gcp:
+	kubectl	--context=$(MGMTCTXT) delete -f $(BUILD_DIR)/gcp_config

--- a/kubeflow/common/cluster/upstream/cluster.yaml
+++ b/kubeflow/common/cluster/upstream/cluster.yaml
@@ -45,14 +45,23 @@ spec:
   releaseChannel:
     # Per https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/194
     # use upper case for the channels
-    channel: REGULAR
-  location: LOCATION # {"$kpt-set":"location"}
+    channel: UNSPECIFIED
+  nodeVersion: '1.18'
+  # Master version controls the kubernetes API version.
+  # Future upgrade of master version might break Kubeflow deployment.
+  # Therefore we need to pin master version and disable minor version upgrade.
+  # Autopilot will enforce automatic node upgrade.
+  minMasterVersion: '1.18' 
+  # This feature is very new: https://github.com/GoogleCloudPlatform/k8s-config-connector/releases/tag/v1.46.0
+  # If you encounter an issue that this field is unknown, remove this field from here for now.
+  enableAutopilot: false
+  location: location # {"$kpt-set":"location"}
   workloadIdentityConfig:
-    identityNamespace: PROJECT.svc.id.goog # {"$kpt-set":"identity-ns"}
+    identityNamespace: project-id.svc.id.goog # {"$kpt-set":"identity-ns"}
   loggingService: logging.googleapis.com/kubernetes
   monitoringService: monitoring.googleapis.com/kubernetes
   nodeConfig:
-    machineType: n1-standard-8
+    machineType: e2-standard-8
     metadata:
       disable-legacy-endpoints: "true"
     oauthScopes:
@@ -60,8 +69,6 @@ spec:
     - https://www.googleapis.com/auth/monitoring
     - https://www.googleapis.com/auth/devstorage.read_only
     serviceAccountRef:
-      name: KUBEFLOW-NAME-vm # {"$kpt-set":"name-vm"}
+      name: name-vm # {"$kpt-set":"name-vm"}
     workloadMetadataConfig:
       nodeMetadata: GKE_METADATA_SERVER
-  nodeVersion: '1.18'
-  minMasterVersion: '1.18'

--- a/kubeflow/common/cluster/upstream/cluster.yaml
+++ b/kubeflow/common/cluster/upstream/cluster.yaml
@@ -45,16 +45,15 @@ spec:
   releaseChannel:
     # Per https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/194
     # use upper case for the channels
-    channel: UNSPECIFIED
-  nodeVersion: '1.18'
+    channel: STABLE
   # Master version controls the kubernetes API version.
   # Future upgrade of master version might break Kubeflow deployment.
-  # Therefore we need to pin master version and disable minor version upgrade.
-  # Autopilot will enforce automatic node upgrade.
+  # At the time of writing, STABLE release channel is using 0.17.
+  # The kubernetes version requirement is 1.17+. Therefore we don't
+  # need to enforce master version. But make sure to review for future release.
+  # Autopilot mode will enforce automatic node upgrade.
   minMasterVersion: '1.18' 
-  # This feature is very new: https://github.com/GoogleCloudPlatform/k8s-config-connector/releases/tag/v1.46.0
-  # If you encounter an issue that this field is unknown, remove this field from here for now.
-  enableAutopilot: false
+  nodeVersion: '1.18'
   location: LOCATION # {"$kpt-set":"location"}
   workloadIdentityConfig:
     identityNamespace: PROJECT.svc.id.goog # {"$kpt-set":"identity-ns"}

--- a/kubeflow/common/cluster/upstream/cluster.yaml
+++ b/kubeflow/common/cluster/upstream/cluster.yaml
@@ -48,7 +48,7 @@ spec:
     channel: STABLE
   # Master version controls the kubernetes API version.
   # Future upgrade of master version might break Kubeflow deployment.
-  # At the time of writing, STABLE release channel is using 0.17.
+  # At the time of writing, STABLE release channel is using 1.17.
   # The kubernetes version requirement is 1.17+. Therefore we don't
   # need to enforce master version. But make sure to review for future release.
   # Autopilot mode will enforce automatic node upgrade.

--- a/kubeflow/common/cluster/upstream/cluster.yaml
+++ b/kubeflow/common/cluster/upstream/cluster.yaml
@@ -52,8 +52,8 @@ spec:
   # The kubernetes version requirement is 1.17+. Therefore we don't
   # need to enforce master version. But make sure to review for future release.
   # Autopilot mode will enforce automatic node upgrade.
-  minMasterVersion: '1.18' 
-  nodeVersion: '1.18'
+  # minMasterVersion: '1.18' 
+  # nodeVersion: '1.18'
   location: LOCATION # {"$kpt-set":"location"}
   workloadIdentityConfig:
     identityNamespace: PROJECT.svc.id.goog # {"$kpt-set":"identity-ns"}

--- a/kubeflow/common/cluster/upstream/cluster.yaml
+++ b/kubeflow/common/cluster/upstream/cluster.yaml
@@ -55,9 +55,9 @@ spec:
   # This feature is very new: https://github.com/GoogleCloudPlatform/k8s-config-connector/releases/tag/v1.46.0
   # If you encounter an issue that this field is unknown, remove this field from here for now.
   enableAutopilot: false
-  location: location # {"$kpt-set":"location"}
+  location: LOCATION # {"$kpt-set":"location"}
   workloadIdentityConfig:
-    identityNamespace: project-id.svc.id.goog # {"$kpt-set":"identity-ns"}
+    identityNamespace: PROJECT.svc.id.goog # {"$kpt-set":"identity-ns"}
   loggingService: logging.googleapis.com/kubernetes
   monitoringService: monitoring.googleapis.com/kubernetes
   nodeConfig:
@@ -69,6 +69,6 @@ spec:
     - https://www.googleapis.com/auth/monitoring
     - https://www.googleapis.com/auth/devstorage.read_only
     serviceAccountRef:
-      name: name-vm # {"$kpt-set":"name-vm"}
+      name: KUBEFLOW-NAME-vm # {"$kpt-set":"name-vm"}
     workloadMetadataConfig:
       nodeMetadata: GKE_METADATA_SERVER

--- a/packages/gcp-resources/cnrm/cluster/cluster.yaml
+++ b/packages/gcp-resources/cnrm/cluster/cluster.yaml
@@ -45,14 +45,14 @@ spec:
   releaseChannel:
     # Per https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/194
     # use upper case for the channels
-    channel: UNSPECIFIED
+    channel: REGULAR
   location: location # {"$kpt-set":"location"}
   workloadIdentityConfig:
     identityNamespace: project-id.svc.id.goog # {"$kpt-set":"identity-ns"}
   loggingService: logging.googleapis.com/kubernetes
   monitoringService: monitoring.googleapis.com/kubernetes
   nodeConfig:
-    machineType: e2-standard-8
+    machineType: n1-standard-8
     metadata:
       disable-legacy-endpoints: "true"
     oauthScopes:
@@ -63,6 +63,3 @@ spec:
       name: name-vm # {"$kpt-set":"name-vm"}
     workloadMetadataConfig:
       nodeMetadata: GKE_METADATA_SERVER
-  nodeVersion: '1.18'
-  minMasterVersion: '1.18' 
-

--- a/packages/gcp-resources/cnrm/cluster/cluster.yaml
+++ b/packages/gcp-resources/cnrm/cluster/cluster.yaml
@@ -45,14 +45,14 @@ spec:
   releaseChannel:
     # Per https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/194
     # use upper case for the channels
-    channel: REGULAR
+    channel: UNSPECIFIED
   location: location # {"$kpt-set":"location"}
   workloadIdentityConfig:
     identityNamespace: project-id.svc.id.goog # {"$kpt-set":"identity-ns"}
   loggingService: logging.googleapis.com/kubernetes
   monitoringService: monitoring.googleapis.com/kubernetes
   nodeConfig:
-    machineType: n1-standard-8
+    machineType: e2-standard-8
     metadata:
       disable-legacy-endpoints: "true"
     oauthScopes:
@@ -63,3 +63,6 @@ spec:
       name: name-vm # {"$kpt-set":"name-vm"}
     workloadMetadataConfig:
       nodeMetadata: GKE_METADATA_SERVER
+  nodeVersion: '1.18'
+  minMasterVersion: '1.18' 
+


### PR DESCRIPTION
Fix #213 
Fix #214

Prevent future deprecation of GCP dependencies, pin k8s version in Kubeflow 1.3 release.
N1 is going to be deprecated, we will use the equivalent machine type in E2.