### PR TITLE
(asm) Use kpt to set asm namepsace label, use revision to download install_asm script and package. Issue #144, Fix #224 

### DIFF
--- a/kubeflow/apps/profiles/Kptfile
+++ b/kubeflow/apps/profiles/Kptfile
@@ -1,0 +1,13 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: profiles
+packageMetadata:
+  shortDescription: profile controller config.
+openAPI:
+  definitions:
+    io.k8s.cli.setters.asm-label:
+      x-k8s-cli:
+        setter:
+          name: asm-label
+          value: ASM-LABEL

--- a/kubeflow/apps/profiles/namespace-labels.yaml
+++ b/kubeflow/apps/profiles/namespace-labels.yaml
@@ -1,3 +1,3 @@
 # Below is a list of labels to be enforced.
 istio-injection: ''
-istio.io/rev: 'asm-192-1' 
+istio.io/rev: ASM-LABEL # {"$kpt-set":"asm-label"}

--- a/kubeflow/common/asm/Makefile
+++ b/kubeflow/common/asm/Makefile
@@ -1,27 +1,41 @@
+# Get a list of stable versions of install_asm and config by running this command
+# curl https://storage.googleapis.com/csm-artifacts/asm/STABLE_VERSIONS
+# For example: 1.9.2-asm.1+config4:install_asm_1.9.2-asm.1-config4
+# The part before colon symbol should be used for ASM_PACKAGE_VERSION.
+# The part after colon symbol should be used for INSTALL_ASM_SCRIPT_VERSION.
+# You might need to change corresponding kpt value in kubeflow/kpt-set.sh if you upgrade 
+ASM_PACKAGE_VERSION=1.9.2-asm.1+config4
+INSTALL_ASM_SCRIPT_VERSION=install_asm_1.9.2-asm.1-config4
+
 
 # The name of the context for your Kubeflow cluster
 NAME=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.name".x-k8s-cli.setter.value')
 LOCATION=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.location".x-k8s-cli.setter.value')
 PROJECT=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.gcloud.core.project".x-k8s-cli.setter.value')
 
-.PHONY: install-asm-script
-install-asm-script:
-	mkdir -p ./asm;
-	cd ./asm && { \
-		curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_1.9 > install_asm; \
-		curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_1.9.sha256 > install_asm.sha256; \
-		sha256sum -c --ignore-missing install_asm.sha256; \
-		chmod +x install_asm; \
-		cd -;}
+.PHONY: downalod-install-asm-script
+downalod-install-asm-script:
+	curl https://storage.googleapis.com/csm-artifacts/asm/$(INSTALL_ASM_SCRIPT_VERSION) > install_asm;
+# Official documentation of downloading install_asm: https://cloud.google.com/service-mesh/docs/scripted-install/asm-onboarding#downloading_the_script
+# It cannot control the patch version so we won't use this approach for now.
+# cd ./asm && { \
+# 	curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_1.9 > install_asm; \
+# 	curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_1.9.sha256 > install_asm.sha256; \
+# 	sha256sum -c --ignore-missing install_asm.sha256; \
+# 	chmod +x install_asm; \
+# 	cd -;}
+
+.PHONY: download-asm-package
+download-asm-package:
+	rm -rf ./asm
+	kpt pkg get https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages.git/asm@$(ASM_PACKAGE_VERSION) ./
 
 .PHONY: install-asm
-install-asm: install-asm-script
-	rm -rf ./asm
-	kpt pkg get https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages.git/asm@1.9.1-asm.1+config3 ./
+install-asm: downalod-install-asm-script download-asm-package
 	./install_asm \
 	--project_id $(PROJECT) \
 	--cluster_name $(NAME) \
 	--cluster_location $(LOCATION) \
 	--mode install \
 	--enable_all \
-	--custom_overlay ./asm/istio/options/iap-operator.yaml
+	--custom_overlay ./asm/istio/options/iap-operator.yaml 

--- a/kubeflow/common/knative/Kptfile
+++ b/kubeflow/common/knative/Kptfile
@@ -1,9 +1,9 @@
 apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
-  name: profiles
+  name: knative
 packageMetadata:
-  shortDescription: profile controller config.
+  shortDescription: knative config.
 openAPI:
   definitions:
     io.k8s.cli.setters.asm-label:

--- a/kubeflow/common/knative/Kptfile
+++ b/kubeflow/common/knative/Kptfile
@@ -1,0 +1,13 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: profiles
+packageMetadata:
+  shortDescription: profile controller config.
+openAPI:
+  definitions:
+    io.k8s.cli.setters.asm-label:
+      x-k8s-cli:
+        setter:
+          name: asm-label
+          value: ASM-LABEL

--- a/kubeflow/common/knative/patches/namespace-patch.yaml
+++ b/kubeflow/common/knative/patches/namespace-patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kubeflow
+  name: knative-serving
   labels:
     istio.io/rev: ASM-LABEL # {"$kpt-set":"asm-label"}
     istio-injection: null

--- a/kubeflow/common/kubeflow-namespace/Kptfile
+++ b/kubeflow/common/kubeflow-namespace/Kptfile
@@ -1,9 +1,9 @@
 apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
-  name: profiles
+  name: kubeflow-namespace
 packageMetadata:
-  shortDescription: profile controller config.
+  shortDescription: kubeflow-namespace config.
 openAPI:
   definitions:
     io.k8s.cli.setters.asm-label:

--- a/kubeflow/common/kubeflow-namespace/Kptfile
+++ b/kubeflow/common/kubeflow-namespace/Kptfile
@@ -1,0 +1,13 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: profiles
+packageMetadata:
+  shortDescription: profile controller config.
+openAPI:
+  definitions:
+    io.k8s.cli.setters.asm-label:
+      x-k8s-cli:
+        setter:
+          name: asm-label
+          value: ASM-LABEL

--- a/kubeflow/env.sh
+++ b/kubeflow/env.sh
@@ -1,9 +1,10 @@
-KF_NAME=<kubeflow-cluster-name>
-KF_PROJECT=<gcp-project-id>
-KF_DIR=<kubeflow-download-path>
-MGMT_NAME=<management-cluster-name>
-MGMTCTXT=${MGMT_NAME}
-LOCATION=<zone>
+export KF_NAME=<kubeflow-cluster-name>
+export KF_PROJECT=<gcp-project-id>
+export KF_DIR=<kubeflow-download-path>
+export MGMT_NAME=<management-cluster-name>
+export MGMTCTXT=${MGMT_NAME}
+export LOCATION=<zone>
 
+export ASM_LABEL=asm-192-1
 
 

--- a/kubeflow/kpt-set.sh
+++ b/kubeflow/kpt-set.sh
@@ -2,6 +2,7 @@
 # Use kpt to set kustomize values
 
 kpt cfg set -R .  gke.private false
+kpt cfg set -R .  asm-label asm-192-1
 
 kpt cfg set -R .  mgmt-ctxt ${MGMT_NAME}
 

--- a/kubeflow/kpt-set.sh
+++ b/kubeflow/kpt-set.sh
@@ -2,7 +2,7 @@
 # Use kpt to set kustomize values
 
 kpt cfg set -R .  gke.private false
-kpt cfg set -R .  asm-label asm-192-1
+kpt cfg set -R .  asm-label ${ASM_LABEL}
 
 kpt cfg set -R .  mgmt-ctxt ${MGMT_NAME}
 


### PR DESCRIPTION
Issue #144
Fix #224 

Document how to pin ASM version in Makefile.
Use kpt cfg set for all ASM namespace labels. The value of these labels `istio.io/rev=asm-XXX-X` need to be consistent across cluster.