### PR TITLE
(Makefile) Run make apply-v3 to apply all components and deployment steps. #230

### DIFF
--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -1,3 +1,4 @@
+
 # The name of the context for the management cluster
 # These are read using yq from the Kptfile.
 MGMTCTXT=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.mgmt-ctxt".x-k8s-cli.setter.value')
@@ -50,6 +51,67 @@ apply-cnrm:
 	rm -rf $(BUILD_DIR)/gcp_config && mkdir -p $(BUILD_DIR)/gcp_config
 	kustomize build --load-restrictor LoadRestrictionsNone -o $(BUILD_DIR)/gcp_config ./common/cnrm
 	kubectl --context=$(MGMTCTXT) apply -f ./$(BUILD_DIR)/gcp_config
+
+.PHONY: apply-component
+apply-component: validate-values check-name 
+ifeq ($(component_path),)
+	$(error component_path is not set for apply-component rule); 
+endif
+	echo 'Component path: $(component_path)' 
+	$(eval makefile_path = ./$(component_path)/Makefile)
+	echo 'Apply component resources: $(component_path)'
+	@if [ -f $(makefile_path) ] ; then \
+		echo 'Found Makefile, call `make apply` of this component Makefile.'; \
+		NAME=$(NAME) KFCTXT=$(KFCTXT) LOCATION=$(LOCATION) PROJECT=$(PROJECT) $(MAKE) -C $(component_path) apply build_dir=$(BUILD_DIR); \
+	else \
+		echo 'Makefile not found, use kustomize and kubectl to apply resources.'; \
+		component_build_dir=./$(component_path)/$(BUILD_DIR); \
+		rm -rf $$component_build_dir && mkdir -p $$component_build_dir; \
+		kustomize build --load-restrictor LoadRestrictionsNone -o $$component_build_dir ./$(component_path); \
+		kubectl --context=$(KFCTXT) apply -f $$component_build_dir; \
+	fi
+
+
+components= \
+common/cnrm \
+common/asm \
+common/iap-secret \
+common/kubeflow-namespace \
+common/istio \
+common/cert-manager \
+contrib/metacontroller \
+common/cloud-endpoints \
+common/iap-ingress \
+common/config-kubeflow \
+apps/admission-webhook \
+apps/centraldashboard \
+common/kubeflow-roles \
+apps/jupyter \
+apps/volumes-web-app \
+apps/tensorboard \
+apps/profiles \
+apps/pytorch-job \
+apps/tf-training \
+apps/pipeline \
+common/knative \
+apps/kfserving \
+common/user-namespace \
+apps/katib \
+common/kubeflow-issuer \
+
+
+.PHONY: apply-v3
+apply-v3: validate-values check-name 
+	@for component in $(components) ; do \
+	$(MAKE) apply-component component_path=$$component || break ; \
+	done
+
+	# Kick the IAP pod because we will reset the policy and need to patch it.
+	# TODO(https://github.com/kubeflow/gcp-blueprints/issues/14)
+	kubectl --context=$(KFCTXT) -n istio-system delete pods -l service=iap-enabler
+	# Kick the backend updater pod, because information might be outdated after the apply.
+	# https://github.com/kubeflow/gcp-blueprints/issues/160
+	kubectl --context=$(KFCTXT) -n istio-system delete pods -l service=backend-updater
 
 .PHONY: apply-kubeflow
 apply-kubeflow: validate-values check-name 

--- a/kubeflow/apps/kfserving/Makefile
+++ b/kubeflow/apps/kfserving/Makefile
@@ -1,0 +1,8 @@
+
+.PHONY: apply
+apply:
+# App kfserving
+	rm -rf $(build_dir) && mkdir -p $(build_dir)
+	kustomize build --load-restrictor LoadRestrictionsNone -o $(build_dir) ./
+	kubectl --context=$(KFCTXT) apply -f ./$(build_dir)
+	kubectl --context=$(KFCTXT) patch cm config-domain --namespace knative-serving --type merge -p '{"data":{"$(NAME).endpoints.$(PROJECT).cloud.goog": ""}}'

--- a/kubeflow/common/asm/Makefile
+++ b/kubeflow/common/asm/Makefile
@@ -41,3 +41,6 @@ install-asm: downalod-install-asm-script download-asm-package
 	--custom_overlay ./asm/istio/options/iap-operator.yaml \
 	--custom_overlay ./options/ingressgateway-iap.yaml 
 
+
+.PHONY: apply
+apply: install-asm

--- a/kubeflow/common/cert-manager/Makefile
+++ b/kubeflow/common/cert-manager/Makefile
@@ -1,0 +1,12 @@
+
+.PHONY: apply
+apply:
+	# Common cert-manager
+	rm -rf $(build_dir) && mkdir -p $(build_dir)
+	kustomize build --load-restrictor LoadRestrictionsNone -o $(build_dir) ./
+# Try kpt live apply to simplify this steps.
+	kubectl --context=$(KFCTXT) apply -f ./$(build_dir)/*v1_namespace_cert-manager.yaml
+	kubectl --context=$(KFCTXT) apply --recursive=true -f ./$(build_dir)
+	kubectl --context=$(KFCTXT) -n cert-manager wait --for=condition=Available --timeout=600s deploy cert-manager-webhook
+	kubectl --context=$(KFCTXT) -n cert-manager wait --for=condition=Available --timeout=600s deploy cert-manager
+	kubectl --context=$(KFCTXT) -n cert-manager wait --for=condition=Available --timeout=600s deploy cert-manager-cainjector

--- a/kubeflow/common/cloud-endpoints/kustomization.yaml
+++ b/kubeflow/common/cloud-endpoints/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+bases:
+- ./base
 patchesStrategicMerge:
 - service-accounts.yaml

--- a/kubeflow/common/cnrm/Makefile
+++ b/kubeflow/common/cnrm/Makefile
@@ -1,9 +1,9 @@
 
 # The name of the context for your Kubeflow cluster
-MGMTCTXT=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.mgmt-ctxt".x-k8s-cli.setter.value')
-NAME=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.name".x-k8s-cli.setter.value')
-LOCATION=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.location".x-k8s-cli.setter.value')
-PROJECT=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.gcloud.core.project".x-k8s-cli.setter.value')
+# MGMTCTXT=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.mgmt-ctxt".x-k8s-cli.setter.value')
+# NAME=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.name".x-k8s-cli.setter.value')
+# LOCATION=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.location".x-k8s-cli.setter.value')
+# PROJECT=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.gcloud.core.project".x-k8s-cli.setter.value')
 
 # You may override the variable by env var if you customized the deployment
 # and deploy fewer or more types of resources.
@@ -30,3 +30,19 @@ create-ctxt:
 	PROJECT=$(PROJECT) \
 	   REGION=$(LOCATION) \
 	   NAME=$(NAME) ../../hack/create_context.sh
+
+.PHONY: apply-cnrm
+apply-cnrm:
+ifeq ($(build_dir),)
+	$(error build_dir is not set for apply rule); 
+endif
+	rm -rf $(build_dir) && mkdir -p $(build_dir)
+	kustomize build --load-restrictor LoadRestrictionsNone -o $(build_dir) ./
+	kubectl --context=$(MGMTCTXT) apply -f ./$(build_dir)
+
+.PHONY: apply
+apply:
+	echo $(build_dir)
+	$(MAKE) apply-cnrm build_dir=$(build_dir)
+	$(MAKE) wait-gcp
+	$(MAKE) create-ctxt

--- a/kubeflow/common/iap-secret/Makefile
+++ b/kubeflow/common/iap-secret/Makefile
@@ -1,0 +1,14 @@
+# The name of the context for your Kubeflow cluster
+# NAME=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.name".x-k8s-cli.setter.value')
+# KFCTXT=$(NAME)
+
+.PHONY: apply
+apply: iap-secret
+
+.PHONY: iap-secret
+iap-secret: check-iap
+	kubectl --context=$(KFCTXT) -n istio-system create secret generic kubeflow-oauth --from-literal=client_id=$(CLIENT_ID) --from-literal=client_secret=$(CLIENT_SECRET) --dry-run=client -o yaml | kubectl apply -f -
+
+.PHONY: check-iap
+check-iap:
+	../../hack/check_oauth_secret.sh

--- a/kubeflow/common/knative/Makefile
+++ b/kubeflow/common/knative/Makefile
@@ -1,0 +1,23 @@
+# The name of the context for your Kubeflow cluster
+# NAME=$(shell yq r ./Kptfile 'openAPI.definitions."io.k8s.cli.setters.name".x-k8s-cli.setter.value')
+# KFCTXT=$(NAME)
+
+.PHONY: apply
+apply:
+# Common Knative
+# It has error when trying to patch the resource downloaded from knative because it doesn't match kustomize requirement.
+# Original release of knative manifest can not be patched by kustomize because of `already registered id`. For now we run kubectl directly.
+	rm -rf $(build_dir) && mkdir -p $(build_dir)
+	kustomize build -o $(build_dir) ./
+	kubectl --context=${KFCTXT} apply -f ./$(build_dir)/*v1_namespace_knative-serving.yaml
+	kubectl --context=${KFCTXT} apply -f ./$(build_dir)/*v1_customresourcedefinition_certificates.networking.internal.knative.dev.yaml
+	kubectl --context=${KFCTXT} apply -f ./$(build_dir)/*v1_customresourcedefinition_configurations.serving.knative.dev.yaml
+	kubectl --context=${KFCTXT} apply -f ./$(build_dir)/*v1_customresourcedefinition_images.caching.internal.knative.dev.yaml
+	kubectl --context=${KFCTXT} apply -f ./$(build_dir)/*v1_customresourcedefinition_ingresses.networking.internal.knative.dev.yaml
+	kubectl --context=${KFCTXT} apply -f ./$(build_dir)/*v1_customresourcedefinition_metrics.autoscaling.internal.knative.dev.yaml
+	kubectl --context=${KFCTXT} apply -f ./$(build_dir)/*v1_customresourcedefinition_podautoscalers.autoscaling.internal.knative.dev.yaml
+	kubectl --context=${KFCTXT} apply -f ./$(build_dir)/*v1_customresourcedefinition_revisions.serving.knative.dev.yaml
+	kubectl --context=${KFCTXT} apply -f ./$(build_dir)/*v1_customresourcedefinition_routes.serving.knative.dev.yaml
+	kubectl --context=${KFCTXT} apply -f ./$(build_dir)/*v1_customresourcedefinition_serverlessservices.networking.internal.knative.dev.yaml
+	kubectl --context=${KFCTXT} apply -f ./$(build_dir)/*v1_customresourcedefinition_services.serving.knative.dev.yaml
+	kubectl --context=$(KFCTXT) apply --recursive=true -f ./$(build_dir)

--- a/kubeflow/common/kubeflow-issuer/kustomization.yaml
+++ b/kubeflow/common/kubeflow-issuer/kustomization.yaml
@@ -1,0 +1,6 @@
+# Define the self-signed issuer for Kubeflow
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cert-manager
+resources:
+- ../cert-manager/cert-manager-1-3/cert-manager/kubeflow-issuer

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -7,6 +7,9 @@ export KUBEFLOW_MANIFESTS_VERSION=v1.3.0-rc.0
 # export KUBEFLOW_MANIFESTS_VERSION=v1.2.0
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
 
+export KUBEFLOW_PIPELINES_VERSION=1.5.0
+export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
+
 # apps/ related manifest
 if [ -d apps/admission-webhook/upstream ]; then
     rm -rf apps/admission-webhook/upstream
@@ -32,6 +35,13 @@ if [ -d apps/jupyter/notebook-controller/upstream ]; then
 fi
 mkdir -p apps/jupyter/notebook-controller
 kpt pkg get $KUBEFLOW_MANIFESTS_REPO/apps/jupyter/notebook-controller/upstream@$KUBEFLOW_MANIFESTS_VERSION apps/jupyter/notebook-controller
+
+if [ -d apps/pipeline/upstream ]; then
+    rm -rf apps/pipeline/upstream
+fi
+mkdir -p apps/pipeline/upstream
+kpt pkg get $KUBEFLOW_PIPELINES_REPO/manifests/kustomize/@$KUBEFLOW_PIPELINES_VERSION apps/pipeline/upstream
+mv apps/pipeline/upstream/kustomize/* apps/pipeline/upstream
 
 if [ -d apps/profiles/upstream ]; then
     rm -rf apps/profiles/upstream


### PR DESCRIPTION
Partial #230


This PR implements the core functionality of #230 - `make apply`

The way to initialize and deploy:

1. set all values in env.sh and kpt-set.sh
2. Set CLIENT_ID and CLIENT_SECRET
3. $ source env.sh
4. $ bash ./pull-upstream.sh
5. $ bash kpt-set.sh
6. $ make apply-v3

Rules like `hydrate`, `delete`, `clean-build` are not implemented yet. We need to remove existing rule in Makefile later on.