### PR TITLE
(kubeflow/manifests) Upgrade upstream to Kubeflow 1.3. Fix #233

### DIFF
--- a/kubeflow/apps/katib/kustomization.yaml
+++ b/kubeflow/apps/katib/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
 resources:
-- upstream/installs/katib-with-kubeflow-cert-manager
+- upstream/installs/katib-with-kubeflow

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-export KUBEFLOW_MANIFESTS_VERSION=v1.3.0-rc.0
-# export KUBEFLOW_MANIFESTS_VERSION=v1.3.0
+# export KUBEFLOW_MANIFESTS_VERSION=v1.3.0-rc.0
+export KUBEFLOW_MANIFESTS_VERSION=v1.3.0
 # export KUBEFLOW_MANIFESTS_VERSION=v1.2.0
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
 


### PR DESCRIPTION
Fix #233

Change upstream tag to 1.3.0
Change Katib target.
Validated that RStudio trademark is removed.