### PR TITLE
(Cluster) Set starting k8s version to be 1.18. Fix #243

### DIFF
--- a/kubeflow/common/cluster/upstream/cluster.yaml
+++ b/kubeflow/common/cluster/upstream/cluster.yaml
@@ -49,11 +49,11 @@ spec:
   # Master version controls the kubernetes API version.
   # Future upgrade of master version might break Kubeflow deployment.
   # At the time of writing, STABLE release channel is using 1.17.
-  # The kubernetes version requirement is 1.17+. Therefore we don't
-  # need to enforce master version. But make sure to review for future release.
+  # knative requires Kubernetes version to be 1.18+. Therefore we set 
+  # master version below. We need to make sure reviewing this for future release.
   # Autopilot mode will enforce automatic node upgrade.
-  # minMasterVersion: '1.18' 
-  # nodeVersion: '1.18'
+  minMasterVersion: '1.18'
+  nodeVersion: '1.18'
   location: LOCATION # {"$kpt-set":"location"}
   workloadIdentityConfig:
     identityNamespace: PROJECT.svc.id.goog # {"$kpt-set":"identity-ns"}


### PR DESCRIPTION
Fix #243

Screenshot for the deployment: 
![3QBVCnVfgh2LivP](https://user-images.githubusercontent.com/37026441/116455177-9f942d80-a815-11eb-94c5-cc38bea0e6fe.png)
