### PR TITLE
(iap-ingress) Patch BackendConfig healthcheck port with the correct port number

### DIFF
--- a/kubeflow/common/iap-ingress/base/cluster-role.yaml
+++ b/kubeflow/common/iap-ingress/base/cluster-role.yaml
@@ -17,8 +17,10 @@ rules:
 - apiGroups:
   - extensions
   - networking.k8s.io
+  - apps
   resources:
   - ingresses
+  - deployments
   verbs:
   - get
   - list

--- a/kubeflow/common/iap-ingress/base/cluster-role.yaml
+++ b/kubeflow/common/iap-ingress/base/cluster-role.yaml
@@ -39,3 +39,12 @@ rules:
   - virtualservices
   verbs:
   - '*'
+- apiGroups:
+  - cloud.google.com
+  resources:
+  - backendconfigs
+  verbs:
+  - get
+  - list
+  - patch
+  - update

--- a/kubeflow/common/iap-ingress/base/config-map.yaml
+++ b/kubeflow/common/iap-ingress/base/config-map.yaml
@@ -127,13 +127,12 @@ data:
     [ -z ${NAMESPACE} ] && echo Error NAMESPACE must be set && exit 1
 
     set_health_check () {
-      # We need the nodeport for istio-ingressgateway status-port
       # See: https://cloud.google.com/service-mesh/docs/iap-integration#deploying_the_load_balancer
       HC_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="status-port")].nodePort}')
       HC_INGRESS_PATH=$(kubectl -n istio-system get deployments istio-ingressgateway -o jsonpath='{.spec.template.spec.containers[?(@.name=="istio-proxy")].readinessProbe.httpGet.path}')
 
       echo Setting BackendConfig healthCheck.port to: ${HC_INGRESS_PORT} and healthCheck.requestPath to ${HC_INGRESS_PATH}
-      kubectl patch iap-backendconfig -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/healthCheck/port", "value": '${HC_INGRESS_PORT}'}, {"op": "replace", "path": "/spec/healthCheck/requestPath", "value": "${HC_INGRESS_PATH}"}]'
+      kubectl patch backendconfig iap-backendconfig -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/healthCheck/port", "value": '${HC_INGRESS_PORT}'}, {"op": "replace", "path": "/spec/healthCheck/requestPath", "value": "'${HC_INGRESS_PATH}'"}]'
     }
 
     while true; do

--- a/kubeflow/common/iap-ingress/base/config-map.yaml
+++ b/kubeflow/common/iap-ingress/base/config-map.yaml
@@ -125,8 +125,49 @@ data:
     set -x
 
     [ -z ${NAMESPACE} ] && echo Error NAMESPACE must be set && exit 1
+    [ -z ${SERVICE} ] && echo Error SERVICE must be set && exit 1
+    [ -z ${INGRESS_NAME} ] && echo Error INGRESS_NAME must be set && exit 1
+
+    PROJECT=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
+    if [ -z ${PROJECT} ]; then
+      echo Error unable to fetch PROJECT from compute metadata
+      exit 1
+    fi
+    
+    if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+      # TODO(jlewi): As of 0.7 we should always be using workload identity. We can remove it post 0.7.0 once we have workload identity
+      # fully working
+      # Activate the service account, allow 5 retries
+      for i in {1..5}; do gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} && break || sleep 10; done
+    fi  
 
     set_health_check () {
+      NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
+      echo node port is ${NODE_PORT}
+
+      while [[ -z ${BACKEND_NAME} ]]; do
+        BACKENDS=$(kubectl --namespace=${NAMESPACE} get ingress ${INGRESS_NAME} -o jsonpath='{.metadata.annotations.ingress\.kubernetes\.io/backends}')
+        echo "fetching backends info with ${INGRESS_NAME}: ${BACKENDS}"
+      
+        BACKEND_NAME=$(echo $BACKENDS | grep -o "k8s-be-${NODE_PORT}--[0-9a-z]\+")
+        echo "backend name is ${BACKEND_NAME}"
+      
+        sleep 2
+      done
+
+      while [[ -z ${BACKEND_SERVICE} ]]; do
+        BACKEND_SERVICE=$(gcloud --project=${PROJECT} compute backend-services list --filter=name~${BACKEND_NAME} --uri);
+        echo "Waiting for the backend-services resource PROJECT=${PROJECT} BACKEND_NAME=${BACKEND_NAME} SERVICE=${SERVICE}...";
+        sleep 2;
+      done
+
+      while [[ -z ${HEALTH_CHECK_URI} ]]; do
+        HEALTH_CHECK_URI=$(gcloud compute --project=${PROJECT} health-checks list --filter=name~${BACKEND_NAME} --uri);
+        echo "Waiting for the healthcheck resource PROJECT=${PROJECT} NODEPORT=${NODE_PORT} SERVICE=${SERVICE}...";
+        sleep 2;
+      done
+      echo health check URI is ${HEALTH_CHECK_URI}
+
       # See: https://cloud.google.com/service-mesh/docs/iap-integration#deploying_the_load_balancer
       HC_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="status-port")].nodePort}')
       echo Setting BackendConfig healthCheck.port to: ${HC_INGRESS_PORT}

--- a/kubeflow/common/iap-ingress/base/config-map.yaml
+++ b/kubeflow/common/iap-ingress/base/config-map.yaml
@@ -125,65 +125,15 @@ data:
     set -x
 
     [ -z ${NAMESPACE} ] && echo Error NAMESPACE must be set && exit 1
-    [ -z ${SERVICE} ] && echo Error SERVICE must be set && exit 1
-    [ -z ${INGRESS_NAME} ] && echo Error INGRESS_NAME must be set && exit 1
-
-    PROJECT=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
-    if [ -z ${PROJECT} ]; then
-      echo Error unable to fetch PROJECT from compute metadata
-      exit 1
-    fi
-
-    if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
-      # TODO(jlewi): As of 0.7 we should always be using workload identity. We can remove it post 0.7.0 once we have workload identity
-      # fully working
-      # Activate the service account, allow 5 retries
-      for i in {1..5}; do gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} && break || sleep 10; done
-    fi      
 
     set_health_check () {
-      NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
-      echo node port is ${NODE_PORT}
+      # We need the nodeport for istio-ingressgateway status-port
+      # See: https://cloud.google.com/service-mesh/docs/iap-integration#deploying_the_load_balancer
+      HC_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="status-port")].nodePort}')
+      HC_INGRESS_PATH=$(kubectl -n istio-system get deployments istio-ingressgateway -o jsonpath='{.spec.template.spec.containers[?(@.name=="istio-proxy")].readinessProbe.httpGet.path}')
 
-      while [[ -z ${BACKEND_NAME} ]]; do
-        BACKENDS=$(kubectl --namespace=${NAMESPACE} get ingress ${INGRESS_NAME} -o jsonpath='{.metadata.annotations.ingress\.kubernetes\.io/backends}')
-        echo "fetching backends info with ${INGRESS_NAME}: ${BACKENDS}"
-        BACKEND_NAME=$(echo $BACKENDS | grep -o "k8s-be-${NODE_PORT}--[0-9a-z]\+")
-        echo "backend name is ${BACKEND_NAME}"
-        sleep 2
-      done
-
-      while [[ -z ${BACKEND_SERVICE} ]];
-      do BACKEND_SERVICE=$(gcloud --project=${PROJECT} compute backend-services list --filter=name~${BACKEND_NAME} --uri);
-      echo "Waiting for the backend-services resource PROJECT=${PROJECT} BACKEND_NAME=${BACKEND_NAME} SERVICE=${SERVICE}...";
-      sleep 2;
-      done
-
-      while [[ -z ${HEALTH_CHECK_URI} ]];
-      do HEALTH_CHECK_URI=$(gcloud compute --project=${PROJECT} health-checks list --filter=name~${BACKEND_NAME} --uri);
-      echo "Waiting for the healthcheck resource PROJECT=${PROJECT} NODEPORT=${NODE_PORT} SERVICE=${SERVICE}...";
-      sleep 2;
-      done
-
-      echo health check URI is ${HEALTH_CHECK_URI}
-
-      # Since we create the envoy-ingress ingress object before creating the envoy
-      # deployment object, healthcheck will not be configured correctly in the GCP
-      # load balancer. It will default the healthcheck request path to a value of
-      # / instead of the intended /healthz.
-      # Manually update the healthcheck request path to /healthz
-      if [[ ${HEALTHCHECK_PATH} ]]; then
-        # This is basic auth
-        echo Running health checks update ${HEALTH_CHECK_URI} with ${HEALTHCHECK_PATH}
-        gcloud --project=${PROJECT} compute health-checks update http ${HEALTH_CHECK_URI} --request-path=${HEALTHCHECK_PATH}
-      else
-        # /healthz/ready is the health check path for istio-ingressgateway
-        # We need the nodeport for istio-ingressgateway status-port
-        STATUS_NODE_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="status-port")].nodePort}')
-        # Use kubectl patch.
-        echo patch BackendConfig health check port: ${STATUS_NODE_PORT}
-        kubectl patch BackendConfig iap-backendconfig -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/healthCheck/port", "value": '${STATUS_NODE_PORT}'}]'
-      fi      
+      echo Setting BackendConfig healthCheck.port to: ${HC_INGRESS_PORT} and healthCheck.requestPath to ${HC_INGRESS_PATH}
+      kubectl patch iap-backendconfig -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/healthCheck/port", "value": '${HC_INGRESS_PORT}'}, {"op": "replace", "path": "/spec/healthCheck/requestPath", "value": "${HC_INGRESS_PATH}"}]'
     }
 
     while true; do

--- a/kubeflow/common/iap-ingress/base/config-map.yaml
+++ b/kubeflow/common/iap-ingress/base/config-map.yaml
@@ -178,11 +178,11 @@ data:
         gcloud --project=${PROJECT} compute health-checks update http ${HEALTH_CHECK_URI} --request-path=${HEALTHCHECK_PATH}
       else
         # /healthz/ready is the health check path for istio-ingressgateway
-        echo Running health checks update ${HEALTH_CHECK_URI} with /healthz/ready
-        gcloud --project=${PROJECT} compute health-checks update http ${HEALTH_CHECK_URI} --request-path=/healthz/ready
         # We need the nodeport for istio-ingressgateway status-port
         STATUS_NODE_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="status-port")].nodePort}')
-        gcloud --project=${PROJECT} compute health-checks update http ${HEALTH_CHECK_URI} --port=${STATUS_NODE_PORT}
+        # Use kubectl patch.
+        echo patch BackendConfig health check port: ${STATUS_NODE_PORT}
+        kubectl patch BackendConfig iap-backendconfig -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/healthCheck/port", "value": '${STATUS_NODE_PORT}'}]'
       fi      
     }
 

--- a/kubeflow/common/iap-ingress/base/config-map.yaml
+++ b/kubeflow/common/iap-ingress/base/config-map.yaml
@@ -148,10 +148,8 @@ data:
       while [[ -z ${BACKEND_NAME} ]]; do
         BACKENDS=$(kubectl --namespace=${NAMESPACE} get ingress ${INGRESS_NAME} -o jsonpath='{.metadata.annotations.ingress\.kubernetes\.io/backends}')
         echo "fetching backends info with ${INGRESS_NAME}: ${BACKENDS}"
-
         BACKEND_NAME=$(echo $BACKENDS | grep -o "k8s-be-${NODE_PORT}--[0-9a-z]\+")
         echo "backend name is ${BACKEND_NAME}"
-
         sleep 2
       done
 

--- a/kubeflow/common/iap-ingress/base/config-map.yaml
+++ b/kubeflow/common/iap-ingress/base/config-map.yaml
@@ -133,13 +133,13 @@ data:
       echo Error unable to fetch PROJECT from compute metadata
       exit 1
     fi
-    
+
     if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
       # TODO(jlewi): As of 0.7 we should always be using workload identity. We can remove it post 0.7.0 once we have workload identity
       # fully working
       # Activate the service account, allow 5 retries
       for i in {1..5}; do gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} && break || sleep 10; done
-    fi  
+    fi
 
     set_health_check () {
       NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
@@ -148,10 +148,10 @@ data:
       while [[ -z ${BACKEND_NAME} ]]; do
         BACKENDS=$(kubectl --namespace=${NAMESPACE} get ingress ${INGRESS_NAME} -o jsonpath='{.metadata.annotations.ingress\.kubernetes\.io/backends}')
         echo "fetching backends info with ${INGRESS_NAME}: ${BACKENDS}"
-      
+
         BACKEND_NAME=$(echo $BACKENDS | grep -o "k8s-be-${NODE_PORT}--[0-9a-z]\+")
         echo "backend name is ${BACKEND_NAME}"
-      
+
         sleep 2
       done
 

--- a/kubeflow/common/iap-ingress/base/config-map.yaml
+++ b/kubeflow/common/iap-ingress/base/config-map.yaml
@@ -129,10 +129,12 @@ data:
     set_health_check () {
       # See: https://cloud.google.com/service-mesh/docs/iap-integration#deploying_the_load_balancer
       HC_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="status-port")].nodePort}')
+      echo Setting BackendConfig healthCheck.port to: ${HC_INGRESS_PORT}
+      kubectl patch backendconfig iap-backendconfig -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/healthCheck/port", "value": '${HC_INGRESS_PORT}'}]'
+      
       HC_INGRESS_PATH=$(kubectl -n istio-system get deployments istio-ingressgateway -o jsonpath='{.spec.template.spec.containers[?(@.name=="istio-proxy")].readinessProbe.httpGet.path}')
-
-      echo Setting BackendConfig healthCheck.port to: ${HC_INGRESS_PORT} and healthCheck.requestPath to ${HC_INGRESS_PATH}
-      kubectl patch backendconfig iap-backendconfig -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/healthCheck/port", "value": '${HC_INGRESS_PORT}'}, {"op": "replace", "path": "/spec/healthCheck/requestPath", "value": "'${HC_INGRESS_PATH}'"}]'
+      echo Setting BackendConfig healthCheck.requestPath to ${HC_INGRESS_PATH}
+      kubectl patch backendconfig iap-backendconfig -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/healthCheck/requestPath", "value": "'${HC_INGRESS_PATH}'"}]'
     }
 
     while true; do


### PR DESCRIPTION
# Problem
Unhealthy backend due to misconfigured health check.
The `iap-backendconfig` BackendConfig healthCheck spec points to the wrong port. It overwrites `backend-updater` changes.

# Solution
Refactor `update_backend.sh` script (used by `backend-updater` stateful set) to patch the BackendConfig `iap-backendconfig` healthcheck port instead of updating the health-check resource directly.
