### PR TITLE
(management) Add managed project IAM file and kptfile. Partial #252

### DIFF
--- a/management/Kptfile
+++ b/management/Kptfile
@@ -86,3 +86,18 @@ openAPI:
           values:
           - marker: ${gcloud.core.project}
             ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
+    io.k8s.cli.substitutions.managed-project-owner-member:
+      x-k8s-cli:
+        substitution:
+          name: managed-project-owner-member
+          pattern: serviceAccount:${name}-cnrm-system@${gcloud.core.project}.iam.gserviceaccount.com
+          values:
+          - marker: ${name}
+            ref: '#/definitions/io.k8s.cli.setters.name'
+          - marker: ${gcloud.core.project}
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
+    io.k8s.cli.setters.managed-project:
+      x-k8s-cli:
+        setter:
+          name: managed-project
+          value: MANAGED_PROJECT

--- a/management/Kptfile
+++ b/management/Kptfile
@@ -96,6 +96,14 @@ openAPI:
             ref: '#/definitions/io.k8s.cli.setters.name'
           - marker: ${gcloud.core.project}
             ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
+    io.k8s.cli.substitutions.managed-project-policy-name:
+      x-k8s-cli:
+        substitution:
+          name: managed-project-policy-name
+          pattern: cnrm-system-${managed-project}-owner
+          values:
+          - marker: ${managed-project}
+            ref: '#/definitions/io.k8s.cli.setters.managed-project'
     io.k8s.cli.setters.managed-project:
       x-k8s-cli:
         setter:

--- a/management/managed-project/README.md
+++ b/management/managed-project/README.md
@@ -1,0 +1,4 @@
+A simplepackage to grant ownership permissions on a project to
+the GCP service account you are running CNRM with.
+
+The Google Cloud Project where you install Config Connector is known as the host project, or **HOST_PROJECT**. The other projects where you manage resources are known as the managed projects, or **MANAGED_PROJECT**. These could be the same project if you only intend to use Config Connector to create Google Cloud resources in the same project as your cluster.

--- a/management/managed-project/iam.yaml
+++ b/management/managed-project/iam.yaml
@@ -1,7 +1,7 @@
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: cnrm-system-MANAGED_PROJECT-owner
+  name: cnrm-system-MANAGED_PROJECT-owner # {"$kpt-set":"managed-project-policy-name"}
   namespace: MANAGED_PROJECT # {"$kpt-set":"managed-project"}
 spec:
   member: serviceAccount:NAME-cnrm-system@PROJECT.iam.gserviceaccount.com # {"$kpt-set":"managed-project-owner-member"}

--- a/management/managed-project/iam.yaml
+++ b/management/managed-project/iam.yaml
@@ -1,0 +1,14 @@
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: cnrm-system-MANAGED_PROJECT-owner
+  namespace: MANAGED_PROJECT # {"$kpt-set":"managed-project"}
+spec:
+  member: serviceAccount:NAME-cnrm-system@PROJECT.iam.gserviceaccount.com # {"$kpt-set":"managed-project-owner-member"}
+  role: roles/owner
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    # N.B. With anthoscli 0.2.4 this is just the project id
+    # and not projects/MANAGED_PROJECT as used by the CNRM docs.
+    external: MANAGED_PROJECT # {"$kpt-set":"managed-project"}


### PR DESCRIPTION
Partial #252

I need another GCP project to validate this fix. But based on the existing material, I am able to bring back the iam.yaml file from last cleanup.

Submitting this change for now, feel free to comment later on.