### PR TITLE
(profile-controller) Adopt v1.3.0-gcp profile controller 

### DIFF
--- a/kubeflow/apps/profiles/kustomization.yaml
+++ b/kubeflow/apps/profiles/kustomization.yaml
@@ -40,11 +40,11 @@ patchesStrategicMerge:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/access-management
   newName: public.ecr.aws/j1r0q0g6/notebooks/access-management
-  newTag: v1.3.0-rc.0
+  newTag: v1.3.0-rc.1
 # Added for dynamic namespace label change
 - name: public.ecr.aws/j1r0q0g6/notebooks/profile-controller
-  newName: gcr.io/jamxl-kfp-dev/profile-controller
-  newTag: kf-v1.3-rc0
+  newName: gcr.io/kubeflow-images-public/profile-controller
+  newTag: v1.3.0-gcp
 
 # Below is copied from packages/
 configMapGenerator:
@@ -57,4 +57,4 @@ configMapGenerator:
   - gcp-sa=
 - name: namespace-labels-data
   files:
-  - namespace-labels.yaml
+  - patches/namespace-labels.yaml

--- a/kubeflow/apps/profiles/namespace-labels.yaml
+++ b/kubeflow/apps/profiles/namespace-labels.yaml
@@ -1,3 +1,0 @@
-# Below is a list of labels to be enforced.
-istio-injection: ''
-istio.io/rev: ASM-LABEL # {"$kpt-set":"asm-label"}

--- a/kubeflow/apps/profiles/patches/manager.yaml
+++ b/kubeflow/apps/profiles/patches/manager.yaml
@@ -15,7 +15,7 @@ spec:
       - name: manager
         volumeMounts:
         - name: namespace-labels
-          mountPath: /etc/config/labels
+          mountPath: /etc/profile-controller
           readOnly: true
         env:
         - name: USERID_HEADER

--- a/kubeflow/apps/profiles/patches/namespace-labels.yaml
+++ b/kubeflow/apps/profiles/patches/namespace-labels.yaml
@@ -1,0 +1,26 @@
+# Below is a list of labels to be set by default.
+#
+# To add a namespace label, use `key: 'value'`, for example:
+# istio.io/rev: 'asm-191-1'
+#
+# To remove a namespace label, use `key: ''` to remove key, for example:
+# istio-injection: ''
+# 
+# Profile controller will not replace value if namespace label already exists.
+# But profile controller keeps removing namespace label if removing is specified here.
+# In order to change this enforcement:
+# 1. If your profile already has this label:
+#       First, remove this label by using `key: ''` and deploy.
+#       Second, add this label by using `key: 'value'` and deploy.
+# 2. If your profile doesn't have this label:
+#       you can add label and value to this file and deploy.
+# Reason:
+#    Profile controller will enforce flag removal, but not enforce value replacement.
+#   
+katib-metricscollector-injection: 'enabled'
+serving.kubeflow.org/inferenceservice: 'enabled'
+pipelines.kubeflow.org/enabled: 'true'
+app.kubernetes.io/part-of: 'kubeflow-profile'
+# Below is a list of labels to be enforced.
+istio-injection: ''
+istio.io/rev: asm-192-1 # {"$kpt-set":"asm-label"}


### PR DESCRIPTION
This is our current way to adopting https://github.com/kubeflow/kubeflow/pull/5761/files.

I am able to create profile and add contributor via UI and yaml file.

Note that even though I have added sidecar injection label ` istio.io/rev=asm-192-2` to kubeflow namespace. I am not able to inject sidecar for KFP yet. It might not be related to this PR.