### PR TITLE
(management) Specify namespace in wait-gcp command. Fix #252

### DIFF
--- a/kubeflow/common/cnrm/Makefile
+++ b/kubeflow/common/cnrm/Makefile
@@ -18,7 +18,7 @@ wait-gcp:
 	for resource in $(GCP_RESOURCE_TYPES_TO_CHECK); \
 	do \
 		echo "Waiting for $$resource resources..."; \
-		kubectl --context=$(MGMTCTXT) wait --for=condition=Ready --timeout=600s "$${resource}" -l kf-name=$(NAME)  \
+		kubectl --context=$(MGMTCTXT) --namespace=$(PROJECT) wait --for=condition=Ready --timeout=600s "$${resource}" -l kf-name=$(NAME)  \
 		|| (echo "Error: waiting for $${resource} ready timed out."; \
 			echo "To troubleshoot, you can run:"; \
 			echo "kubectl --context=$(MGMTCTXT) describe $${resource} -l kf-name=$(NAME)"; \


### PR DESCRIPTION
Fix #252

We are removing a command to set namespace for management-cluster context, therefore we need to make sure the kubectl command in Makefile is specifying namespace.