### PR TITLE
feat: make KFP v2 compatible mode work out of the box

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ reset-cfg-values:
 	kpt cfg set -R . gcloud.compute.region REGION
 	kpt cfg set -R . bucket-name BUCKET-NAME
 	kpt cfg set -R . cloudsql-name CLOUDSQL-NAME
+	kpt cfg set kubeflow/apps/pipelines default-pipeline-root "minio://mlpipeline/v2/artifacts"
 
 	kpt cfg set -R . email EMAIL
 

--- a/kubeflow/apps/kfserving/Kptfile
+++ b/kubeflow/apps/kfserving/Kptfile
@@ -17,3 +17,4 @@ openAPI:
         setter:
           name: gcloud.core.project
           value: PROJECT
+          isSet: true

--- a/kubeflow/apps/pipelines/Kptfile
+++ b/kubeflow/apps/pipelines/Kptfile
@@ -178,3 +178,9 @@ openAPI:
           name: bucket-name
           value: BUCKET-NAME
           isSet: true
+    io.k8s.cli.setters.default-pipeline-root:
+      x-k8s-cli:
+        setter:
+          name: default-pipeline-root
+          value: minio://mlpipeline/v2/artifacts
+          isSet: true

--- a/kubeflow/apps/pipelines/Makefile
+++ b/kubeflow/apps/pipelines/Makefile
@@ -69,3 +69,7 @@ wait-cnrm:
 .PHONY: status-cnrm
 status-cnrm:
 	kubectl --context=$(MGMTCTXT) get -f $(build_dir)/cnrm
+
+.PHONY: pull-upstream
+pull-upstream:
+	./pull-upstream.sh

--- a/kubeflow/apps/pipelines/gcs/pipeline-install-config-patch.yaml
+++ b/kubeflow/apps/pipelines/gcs/pipeline-install-config-patch.yaml
@@ -20,4 +20,5 @@ metadata:
 # https://github.com/kubeflow/pipelines/blob/1.5.0/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
 data:
   bucketName: BUCKET-NAME # {"$kpt-set":"bucket-name"}
+  defaultPipelineRoot: minio://mlpipeline/v2/artifacts # {"$kpt-set":"default-pipeline-root"}
   gcsProjectId: PROJECT # {"$kpt-set": "gcloud.core.project"}

--- a/kubeflow/apps/pipelines/kustomization.yaml
+++ b/kubeflow/apps/pipelines/kustomization.yaml
@@ -13,7 +13,8 @@ resources:
 # Alternatively, use in-cluster MinIO by:
 # 1. remove cloudsql/pipeline-install-config-patch.yaml from patchesStrategicMerge
 # 2. remove ../gcs/cnrm from ./cnrm/kustomization.yaml
-# 3. comment gcs/minio-gateway above, and uncomment the following line
+# 3. set default-pipeline-root to MinIO: `kpt cfg set . default-pipeline-root minio://mlpipeline/v2/artifacts`
+# 4. comment gcs/minio-gateway above, and uncomment the following line
 # - upstream/third-party/minio/base
 
 # istio config needed by both options

--- a/kubeflow/apps/pipelines/pull-upstream.sh
+++ b/kubeflow/apps/pipelines/pull-upstream.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# export KUBEFLOW_PIPELINES_VERSION=1.5.0
+# export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
+export KUBEFLOW_PIPELINES_VERSION=config-default-pipeline-root
+export KUBEFLOW_PIPELINES_REPO=https://github.com/Bobgy/pipelines.git
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
+
+cd "${DIR}"
+if [ -d upstream ]; then
+    rm -rf upstream
+fi
+mkdir -p upstream
+kpt pkg get "${KUBEFLOW_PIPELINES_REPO}/manifests/kustomize/@${KUBEFLOW_PIPELINES_VERSION}" upstream
+mv upstream/kustomize/* upstream

--- a/kubeflow/apps/pipelines/pull-upstream.sh
+++ b/kubeflow/apps/pipelines/pull-upstream.sh
@@ -16,6 +16,7 @@
 
 set -ex
 
+# TODO(Bobgy): use KFP 1.6.1 when https://github.com/kubeflow/pipelines/pull/5750 is released.
 # export KUBEFLOW_PIPELINES_VERSION=1.5.0
 # export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
 export KUBEFLOW_PIPELINES_VERSION=config-default-pipeline-root

--- a/kubeflow/kpt-set.sh
+++ b/kubeflow/kpt-set.sh
@@ -67,3 +67,4 @@ kpt cfg set common/managed-storage bucket-name "${BUCKET_NAME}"
 # apps/pipelines uses specified CloudSQL and Cloud Storage bucket.
 kpt cfg set apps/pipelines cloudsql-name "${CLOUDSQL_NAME}"
 kpt cfg set apps/pipelines bucket-name "${BUCKET_NAME}"
+kpt cfg set apps/pipelines default-pipeline-root "gs://${BUCKET_NAME}/v2/artifacts/"

--- a/kubeflow/kpt-set.sh
+++ b/kubeflow/kpt-set.sh
@@ -67,4 +67,4 @@ kpt cfg set common/managed-storage bucket-name "${BUCKET_NAME}"
 # apps/pipelines uses specified CloudSQL and Cloud Storage bucket.
 kpt cfg set apps/pipelines cloudsql-name "${CLOUDSQL_NAME}"
 kpt cfg set apps/pipelines bucket-name "${BUCKET_NAME}"
-kpt cfg set apps/pipelines default-pipeline-root "gs://${BUCKET_NAME}/v2/artifacts/"
+kpt cfg set apps/pipelines default-pipeline-root "gs://${BUCKET_NAME}/v2/artifacts"

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -1,12 +1,26 @@
 #!/usr/bin/env bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -ex
 
 export KUBEFLOW_MANIFESTS_VERSION=v1.3.0
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
 
-export KUBEFLOW_PIPELINES_VERSION=1.5.0
-export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
+# Pull Kubeflow Pipelines upstream manifests.
+./apps/pipelines/pull-upstream.sh
 
 # apps/ related manifest
 if [ -d apps/admission-webhook/upstream ]; then
@@ -14,7 +28,6 @@ if [ -d apps/admission-webhook/upstream ]; then
 fi
 mkdir -p apps/admission-webhook
 kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/apps/admission-webhook/upstream@${KUBEFLOW_MANIFESTS_VERSION}" apps/admission-webhook
-
 
 if [ -d apps/centraldashboard/upstream ]; then
     rm -rf apps/centraldashboard/upstream
@@ -33,13 +46,6 @@ if [ -d apps/jupyter/notebook-controller/upstream ]; then
 fi
 mkdir -p apps/jupyter/notebook-controller
 kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/apps/jupyter/notebook-controller/upstream@${KUBEFLOW_MANIFESTS_VERSION}" apps/jupyter/notebook-controller
-
-if [ -d apps/pipelines/upstream ]; then
-    rm -rf apps/pipelines/upstream
-fi
-mkdir -p apps/pipelines/upstream
-kpt pkg get "${KUBEFLOW_PIPELINES_REPO}/manifests/kustomize/@${KUBEFLOW_PIPELINES_VERSION}" apps/pipelines/upstream
-mv apps/pipelines/upstream/kustomize/* apps/pipelines/upstream
 
 if [ -d apps/profiles/upstream ]; then
     rm -rf apps/profiles/upstream


### PR DESCRIPTION
Part of https://github.com/kubeflow/pipelines/issues/5680

Depends on https://github.com/kubeflow/pipelines/pull/5750

Changes:
* configure default pipeline root to gcs bucket using a new kpt setter `default-pipeline-root`
* extract KFP specific pull-upstream script to its own folder, so that admin can only update KFP and deploy