### PR TITLE
[KF 1.3.1] Pin image type to be docker

### DIFF
--- a/kubeflow/common/cluster/upstream/cluster.yaml
+++ b/kubeflow/common/cluster/upstream/cluster.yaml
@@ -61,6 +61,10 @@ spec:
   monitoringService: monitoring.googleapis.com/kubernetes
   nodeConfig:
     machineType: e2-standard-8
+    # To avoid issue with Kubernetes 1.19 or above: https://github.com/kubeflow/pipelines/issues/5714.
+    # Set the image type be Container-Optimized OS with Docker (cos):
+    # https://cloud.google.com/kubernetes-engine/docs/concepts/node-images
+    imageType: cos
     metadata:
       disable-legacy-endpoints: "true"
     oauthScopes:


### PR DESCRIPTION
Reference: https://github.com/kubeflow/pipelines/issues/5714

Make sure that Kubeflow cluster is using docker image type, otherwise pipeline will fail. 

Also related: https://github.com/kubeflow/gcp-blueprints/issues/271#issuecomment-846299401