### PR TITLE
(release): Upgrade from Kubeflow 1.3.0 to 1.3.1

### DIFF
--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-export KUBEFLOW_MANIFESTS_VERSION=v1.3.0
+export KUBEFLOW_MANIFESTS_VERSION=v1.3.1-rc.0
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
 
 export KUBEFLOW_PIPELINES_VERSION=1.5.0
@@ -100,7 +100,7 @@ if [ -d common/istio/upstream/ ]; then
     rm -rf common/istio/upstream/
 fi
 mkdir -p common/istio
-kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/common/istio-1-9-0/@${KUBEFLOW_MANIFESTS_VERSION}" common/istio/upstream/
+kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/common/istio-1-9/@${KUBEFLOW_MANIFESTS_VERSION}" common/istio/upstream/
 
 if [ -d common/cert-manager/upstream/ ]; then
     rm -rf common/cert-manager/upstream/

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-export KUBEFLOW_MANIFESTS_VERSION=v1.3.1-rc.0
+export KUBEFLOW_MANIFESTS_VERSION=v1.3.1
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
 
 export KUBEFLOW_PIPELINES_VERSION=1.5.0


### PR DESCRIPTION
Reference: https://github.com/kubeflow/manifests/issues/1949

Note: 
The integration with istio on manifests needs update, it has changed its folder naming.
Consider upgrading ASM version in the 1.4 release, integration with ASM 1.10.2 looks to be straightforward so far.




