### PR TITLE
kustomize: Use labelTransformer to replace commonLabels. Fix #298

### DIFF
--- a/kubeflow/apps/profiles/kustomization.yaml
+++ b/kubeflow/apps/profiles/kustomization.yaml
@@ -16,8 +16,6 @@ resources:
 # - ../../../kubeflow/upstream/manifests/apps/profiles/upstream/overlays/istio/virtual-service.yaml
 # - ../../../kubeflow/upstream/manifests/apps/profiles/upstream/overlays/application/application.yaml
 
-commonLabels:
-  kustomize.component: profiles
 patchesStrategicMerge:
 - patches/manager.yaml
 - patches/profiles-config.yaml
@@ -55,3 +53,5 @@ configMapGenerator:
   behavior: replace
   files:
   - patches/namespace-labels.yaml
+transformers:
+- label-transformer.yaml

--- a/kubeflow/apps/profiles/label-transformer.yaml
+++ b/kubeflow/apps/profiles/label-transformer.yaml
@@ -1,0 +1,9 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: profiles-label
+labels:
+  kustomize.component: profiles
+fieldSpecs:
+- path: metadata/labels
+  create: true

--- a/kubeflow/common/knative/kustomization.yaml
+++ b/kubeflow/common/knative/kustomization.yaml
@@ -3,10 +3,7 @@ kind: Kustomization
 resources:
 - ./knative-0-22-0/serving-core.yaml
 - ./knative-0-22-0/net-istio.yaml
-namespace: knative-serving
-commonLabels:
-  kustomize.component: knative
-  app.kubernetes.io/component: knative-serving-install
-  app.kubernetes.io/name: knative-serving-install
 patches:
 - path: patches/namespace-patch.yaml
+transformers:
+- label-transformer.yaml

--- a/kubeflow/common/knative/label-transformer.yaml
+++ b/kubeflow/common/knative/label-transformer.yaml
@@ -1,0 +1,11 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: knativeLabel
+labels:
+  kustomize.component: knative
+  app.kubernetes.io/component: knative-serving-install
+  app.kubernetes.io/name: knative-serving-install
+fieldSpecs:
+- path: metadata/labels
+  create: true


### PR DESCRIPTION
Fix #298.

- Remove knative-serving namespace in kustomization, it updated knative-local-gateway to deploy in istio-system namespace.
- Use labelTransformer to allow knative-local-gateway to select istio-ingressgateway.