### PR TITLE
Upgrade kpt 1.0.0-beta.6 and Kubeflow manifests 1.4.0-rc.1. Fix #309

### DIFF
--- a/kubeflow/apps/pipelines/pull-upstream.sh
+++ b/kubeflow/apps/pipelines/pull-upstream.sh
@@ -19,8 +19,8 @@ set -ex
 # TODO(Bobgy): use KFP 1.6.1 when https://github.com/kubeflow/pipelines/pull/5750 is released.
 # export KUBEFLOW_PIPELINES_VERSION=1.7.0
 # export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
-export KUBEFLOW_PIPELINES_VERSION=krmignore # kubeflow14
-export KUBEFLOW_PIPELINES_REPO=https://github.com/zijianjoy/manifests.git
+export KUBEFLOW_PIPELINES_VERSION=upgradekpt # krmignore # kubeflow14
+export KUBEFLOW_PIPELINES_REPO=https://github.com/zijianjoy/pipelines.git
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 
 cd "${DIR}"
@@ -28,6 +28,7 @@ if [ -d upstream ]; then
     rm -rf upstream
 fi
 # mkdir -p upstream
-kpt pkg get "${ZIJIANJOY_MANIFESTS_REPO}/apps/pipeline/upstream/@krmignore" .
+kpt pkg get "${KUBEFLOW_PIPELINES_REPO}/manifests/kustomize/@${KUBEFLOW_PIPELINES_VERSION}" upstream
+rm upstream/Kptfile
 # kpt pkg get "${KUBEFLOW_PIPELINES_REPO}/manifests/kustomize/@${KUBEFLOW_PIPELINES_VERSION}" upstream
 # mv upstream/kustomize/* upstream

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -16,9 +16,8 @@
 
 set -ex
 
-export KUBEFLOW_MANIFESTS_VERSION=v1.4.0-rc.0
+export KUBEFLOW_MANIFESTS_VERSION=v1.4.0-rc.1
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
-export ZIJIANJOY_MANIFESTS_REPO=https://github.com/zijianjoy/manifests.git
 
 # Pull Kubeflow Pipelines upstream manifests.
 ./apps/pipelines/pull-upstream.sh
@@ -42,13 +41,15 @@ if [ -d apps/jupyter/jupyter-web-app/upstream ]; then
     rm -rf apps/jupyter/jupyter-web-app/upstream
 fi
 mkdir -p apps/jupyter/jupyter-web-app
-kpt pkg get "${ZIJIANJOY_MANIFESTS_REPO}/apps/jupyter/jupyter-web-app/upstream@krmignore" apps/jupyter/jupyter-web-app
+kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/apps/jupyter/jupyter-web-app/upstream@${KUBEFLOW_MANIFESTS_VERSION}" apps/jupyter/jupyter-web-app
+rm apps/jupyter/jupyter-web-app/upstream/Kptfile
 
 if [ -d apps/jupyter/notebook-controller/upstream ]; then
     rm -rf apps/jupyter/notebook-controller/upstream
 fi
 mkdir -p apps/jupyter/notebook-controller
-kpt pkg get "${ZIJIANJOY_MANIFESTS_REPO}/apps/jupyter/notebook-controller/upstream@krmignore" apps/jupyter/notebook-controller
+kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/apps/jupyter/notebook-controller/upstream@${KUBEFLOW_MANIFESTS_VERSION}" apps/jupyter/notebook-controller
+rm apps/jupyter/notebook-controller/upstream/Kptfile
 
 if [ -d apps/profiles/upstream ]; then
     rm -rf apps/profiles/upstream
@@ -56,41 +57,47 @@ fi
 mkdir -p apps/profiles
 kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/apps/profiles/upstream@${KUBEFLOW_MANIFESTS_VERSION}" apps/profiles
 
+# TODO: use the versioned upstream instead of master: https://github.com/kubeflow/gcp-blueprints/issues/317
 if [ -d apps/training-operator/upstream ]; then
     rm -rf apps/training-operator/upstream
 fi
 mkdir -p apps/training-operator
-kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/apps/training-operator/upstream@${KUBEFLOW_MANIFESTS_VERSION}" apps/training-operator
+kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/apps/training-operator/upstream@master" apps/training-operator
 
 if [ -d apps/kfserving/upstream ]; then
     rm -rf apps/kfserving/upstream
 fi
 mkdir -p apps/kfserving
-kpt pkg get "${ZIJIANJOY_MANIFESTS_REPO}/apps/kfserving/upstream@krmignore" apps/kfserving
+kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/apps/kfserving/upstream@${KUBEFLOW_MANIFESTS_VERSION}" apps/kfserving
+rm apps/kfserving/upstream/Kptfile
 
 if [ -d apps/katib/upstream ]; then
     rm -rf apps/katib/upstream
 fi
 mkdir -p apps/katib
-kpt pkg get "${ZIJIANJOY_MANIFESTS_REPO}/apps/katib/upstream@krmignore" apps/katib
+kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/apps/katib/upstream@${KUBEFLOW_MANIFESTS_VERSION}" apps/katib
+rm apps/katib/upstream/Kptfile
 
 if [ -d apps/volumes-web-app/upstream ]; then
     rm -rf apps/volumes-web-app/upstream
 fi
 mkdir -p apps/volumes-web-app
-kpt pkg get "${ZIJIANJOY_MANIFESTS_REPO}/apps/volumes-web-app/upstream@krmignore" apps/volumes-web-app
+kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/apps/volumes-web-app/upstream@${KUBEFLOW_MANIFESTS_VERSION}" apps/volumes-web-app
+rm apps/volumes-web-app/upstream/Kptfile
 
 if [ -d apps/tensorboard/tensorboards-web-app/upstream ]; then
     rm -rf apps/tensorboard/tensorboards-web-app/upstream
 fi
 mkdir -p apps/tensorboard/tensorboards-web-app
-kpt pkg get "${ZIJIANJOY_MANIFESTS_REPO}/apps/tensorboard/tensorboards-web-app/upstream@krmignore" apps/tensorboard/tensorboards-web-app
+kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/apps/tensorboard/tensorboards-web-app/upstream@${KUBEFLOW_MANIFESTS_VERSION}" apps/tensorboard/tensorboards-web-app
+rm apps/tensorboard/tensorboards-web-app/upstream/Kptfile
 
 if [ -d apps/tensorboard/tensorboard-controller/upstream ]; then
     rm -rf apps/tensorboard/tensorboard-controller/upstream
 fi
 mkdir -p apps/tensorboard/tensorboard-controller
-kpt pkg get "${ZIJIANJOY_MANIFESTS_REPO}/apps/tensorboard/tensorboard-controller/upstream@krmignore" apps/tensorboard/tensorboard-controller
+kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/apps/tensorboard/tensorboard-controller/upstream@${KUBEFLOW_MANIFESTS_VERSION}" apps/tensorboard/tensorboard-controller
+rm apps/tensorboard/tensorboard-controller/upstream/Kptfile
 
 # common/ related manifest
 if [ -d common/kubeflow-namespace/upstream ]; then
@@ -104,30 +111,35 @@ if [ -d common/istio/upstream/ ]; then
 fi
 mkdir -p common/istio
 kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/common/istio-1-9/@${KUBEFLOW_MANIFESTS_VERSION}" common/istio/upstream/
+rm common/istio/upstream/Kptfile
 
 if [ -d common/cert-manager/upstream/ ]; then
     rm -rf common/cert-manager/upstream/
 fi
 mkdir -p common/cert-manager
-kpt pkg get "${ZIJIANJOY_MANIFESTS_REPO}/common/cert-manager/@krmignore" common/cert-manager/upstream/
+kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/common/cert-manager/@${KUBEFLOW_MANIFESTS_VERSION}" common/cert-manager/upstream/
+rm common/cert-manager/upstream/Kptfile
 
 if [ -d common/kubeflow-roles/upstream/ ]; then
     rm -rf common/kubeflow-roles/upstream/
 fi
 mkdir -p common/kubeflow-roles
 kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/common/kubeflow-roles/@${KUBEFLOW_MANIFESTS_VERSION}" common/kubeflow-roles/upstream/
+rm common/kubeflow-roles/upstream/Kptfile
 
 if [ -d common/knative/upstream/ ]; then
     rm -rf common/knative/upstream/
 fi
 mkdir -p common/knative
 kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/common/knative/@${KUBEFLOW_MANIFESTS_VERSION}" common/knative/upstream/
+rm common/knative/upstream/Kptfile
 
 if [ -d common/user-namespace/upstream ]; then
     rm -rf common/user-namespace/upstream
 fi
 mkdir -p common/user-namespace
 kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/common/user-namespace/@${KUBEFLOW_MANIFESTS_VERSION}" common/user-namespace/upstream/
+rm common/user-namespace/upstream/Kptfile
 
 # contrib/ related manifest
 if [ -d contrib/application/upstream/ ]; then
@@ -135,9 +147,11 @@ if [ -d contrib/application/upstream/ ]; then
 fi
 mkdir -p contrib/application
 kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/contrib/application/@${KUBEFLOW_MANIFESTS_VERSION}" contrib/application/upstream/
+rm contrib/application/upstream/Kptfile
 
 if [ -d contrib/metacontroller/upstream/ ]; then
     rm -rf contrib/metacontroller/upstream/
 fi
 mkdir -p contrib/metacontroller
 kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/contrib/metacontroller/@${KUBEFLOW_MANIFESTS_VERSION}" contrib/metacontroller/upstream/
+rm contrib/metacontroller/upstream/Kptfile


### PR DESCRIPTION
Fix #309
Partial #317, #308, #302.

TODO:

- Wait for new manifests RC for training-operator fix.
- Wait for new kpt to be ready so we can document it.
- Download from manifests upstream instead of zijianjoy/pipelines repo