### PR TITLE
Upgrade yq from v3 to v4 using docker. Fix #319

### DIFF
--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -1,12 +1,12 @@
+PACKAGE_DIR?=$(shell pwd)
 
 # The name of the context for the management cluster
-# These are read using yq from the Kptfile.
-MGMTCTXT=$(shell yq r ./kptconfig/kpt-setter-config.yaml 'data.mgmt-ctxt')
+MGMTCTXT=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.mgmt-ctxt' kptconfig/kpt-setter-config.yaml)
 
 # The name of the context for your Kubeflow cluster
-NAME=$(shell yq r ./kptconfig/kpt-setter-config.yaml 'data.name')
-LOCATION=$(shell yq r ./kptconfig/kpt-setter-config.yaml 'data.location')
-PROJECT=$(shell yq r ./kptconfig/kpt-setter-config.yaml 'data."gcloud.core.project"')
+NAME=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.name' kptconfig/kpt-setter-config.yaml)
+LOCATION=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.location' kptconfig/kpt-setter-config.yaml)
+PROJECT=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data."gcloud.core.project"' kptconfig/kpt-setter-config.yaml)
 
 KFCTXT=$(NAME)
 
@@ -48,7 +48,8 @@ check-name:
 
 
 # Load components to deploy from config.yaml
-components=$(shell yq r config.yaml 'components.*')
+components=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.components[]' config.yaml)
+
 
 .PHONY: clean-build
 clean-build:

--- a/kubeflow/apps/kfserving/Makefile
+++ b/kubeflow/apps/kfserving/Makefile
@@ -1,6 +1,8 @@
 build_dir?=./build
-NAME=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data.name')
-PROJECT=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data."gcloud.core.project"')
+PACKAGE_DIR?=$(shell pwd)/../..
+NAME=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.name' kptconfig/kpt-setter-config.yaml)
+PROJECT=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data."gcloud.core.project"' kptconfig/kpt-setter-config.yaml)
+
 # The kubectl context for your Kubeflow cluster
 KFCTXT=$(NAME)
 

--- a/kubeflow/apps/pipelines/Makefile
+++ b/kubeflow/apps/pipelines/Makefile
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NAME=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data.name')
-KF_PROJECT=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data."gcloud.core.project"')
-# The kubectl context for your management cluster
-MGMTCTXT=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data.mgmt-ctxt')
+PACKAGE_DIR?=$(shell pwd)/../..
+NAME=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.name' kptconfig/kpt-setter-config.yaml)
 # The kubectl context for your Kubeflow cluster
+KF_PROJECT=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data."gcloud.core.project"' kptconfig/kpt-setter-config.yaml)
+# The kubectl context for your management cluster
+MGMTCTXT=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.mgmt-ctxt' kptconfig/kpt-setter-config.yaml)
+
 KFCTXT=$(NAME)
 build_dir?=./build
 

--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -8,9 +8,11 @@ INSTALL_ASM_SCRIPT_VERSION=install_asm_1.10.4-asm.6-config2
 # ASM Upgrade Guide: Check out README.md of the same directory.
 
 # The name of the context for your Kubeflow cluster
-NAME=$(shell yq r ../kptconfig/kpt-setter-config.yaml 'data.name')
-LOCATION=$(shell yq r ../kptconfig/kpt-setter-config.yaml 'data.location')
-PROJECT=$(shell yq r ../kptconfig/kpt-setter-config.yaml 'data."gcloud.core.project"')
+PACKAGE_DIR?=$(shell pwd)/..
+NAME=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.name' kptconfig/kpt-setter-config.yaml)
+PROJECT=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data."gcloud.core.project"' kptconfig/kpt-setter-config.yaml)
+LOCATION=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.location' kptconfig/kpt-setter-config.yaml)
+
 UPSTREAM=upstream
 
 .PHONY: download-install-asm-script

--- a/kubeflow/common/cert-manager/Makefile
+++ b/kubeflow/common/cert-manager/Makefile
@@ -1,5 +1,6 @@
 build_dir?=./build
-NAME=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data.name')
+PACKAGE_DIR?=$(shell pwd)/../..
+NAME=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.name' kptconfig/kpt-setter-config.yaml)
 # The kubectl context for your Kubeflow cluster
 KFCTXT=$(NAME)
 

--- a/kubeflow/common/cnrm/Makefile
+++ b/kubeflow/common/cnrm/Makefile
@@ -1,9 +1,10 @@
 
 # The name of the context for your Kubeflow cluster
-MGMTCTXT=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data.mgmt-ctxt')
-NAME=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data.name')
-LOCATION=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data.location')
-PROJECT=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data."gcloud.core.project"')
+PACKAGE_DIR?=$(shell pwd)/../..
+NAME=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.name' kptconfig/kpt-setter-config.yaml)
+LOCATION=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.location' kptconfig/kpt-setter-config.yaml)
+KF_PROJECT=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data."gcloud.core.project"' kptconfig/kpt-setter-config.yaml)
+MGMTCTXT=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.mgmt-ctxt' kptconfig/kpt-setter-config.yaml)
 build_dir?=./build
 
 # You may override the variable by env var if you customized the deployment
@@ -18,7 +19,7 @@ wait-gcp:
 	for resource in $(GCP_RESOURCE_TYPES_TO_CHECK); \
 	do \
 		echo "Waiting for $$resource resources..."; \
-		kubectl --context=$(MGMTCTXT) --namespace=$(PROJECT) wait --for=condition=Ready --timeout=600s "$${resource}" -l kf-name=$(NAME)  \
+		kubectl --context=$(MGMTCTXT) --namespace=$(KF_PROJECT) wait --for=condition=Ready --timeout=600s "$${resource}" -l kf-name=$(NAME)  \
 		|| (echo "Error: waiting for $${resource} ready timed out."; \
 			echo "To troubleshoot, you can run:"; \
 			echo "kubectl --context=$(MGMTCTXT) describe $${resource} -l kf-name=$(NAME)"; \
@@ -28,7 +29,7 @@ wait-gcp:
 # Create a kubeconfig context for the kubeflow cluster
 .PHONY: create-ctxt
 create-ctxt:
-	PROJECT=$(PROJECT) \
+	PROJECT=$(KF_PROJECT) \
 	   REGION=$(LOCATION) \
 	   NAME=$(NAME) ../../hack/create_context.sh
 

--- a/kubeflow/common/knative/Makefile
+++ b/kubeflow/common/knative/Makefile
@@ -1,5 +1,7 @@
 build_dir?=./build
-NAME=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data.name')
+PACKAGE_DIR?=$(shell pwd)/../..
+NAME=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.name' kptconfig/kpt-setter-config.yaml)
+
 # The kubectl context for your Kubeflow cluster
 KFCTXT=$(NAME)
 

--- a/kubeflow/common/managed-storage/Makefile
+++ b/kubeflow/common/managed-storage/Makefile
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KF_PROJECT=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data."gcloud.core.project"')
-# The kubectl context for your management cluster
-MGMTCTXT=$(shell yq r ../../kptconfig/kpt-setter-config.yaml 'data.mgmt-ctxt')
+PACKAGE_DIR?=$(shell pwd)/../..
+KF_PROJECT=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data."gcloud.core.project"' kptconfig/kpt-setter-config.yaml)
+MGMTCTXT=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.mgmt-ctxt' kptconfig/kpt-setter-config.yaml)
+
 build_dir?=./build
 
 .PHONY: hydrate

--- a/kubeflow/kpt-set.sh
+++ b/kubeflow/kpt-set.sh
@@ -94,4 +94,4 @@ kpt fn eval --image gcr.io/kpt-fn/apply-setters:v0.1 ./common --fn-config ./kptc
 
 # Limitation on setting non-kRM yaml: https://github.com/GoogleContainerTools/kpt/issues/1218
 # TODO: Use kpt fn instead of yq.
-yq write -i apps/profiles/patches/namespace-labels.yaml '"istio.io/rev"' "${ASM_LABEL}"
+docker run --rm -e ASM_LABEL=${ASM_LABEL} -v "${PWD}/":/workdir mikefarah/yq:4 eval '."istio.io/rev" = strenv(ASM_LABEL)' apps/profiles/patches/namespace-labels.yaml 

--- a/management/Makefile
+++ b/management/Makefile
@@ -16,7 +16,7 @@
 # Directory where manifests live. Defaults to current directory.
 # When calling this makefile from a different directory, this should be
 # overriden to relative path from working directory.
-PACKAGE_DIR?=.
+PACKAGE_DIR?=$(PWD)
 BUILD_DIR?=manifests/build
 # Specific package dirs can be overriden with ./instance/xxxx paths, so that
 # users can add kustomize overlays on top of the base package.
@@ -34,9 +34,10 @@ else
 endif
 
 # The values you set via `kpt cfg set` will be stored in Kptfile.
-NAME=$(shell yq r $(PACKAGE_DIR)/kptconfig/kpt-setter-config.yaml 'data.name')
-LOCATION=$(shell yq r $(PACKAGE_DIR)/kptconfig/kpt-setter-config.yaml 'data.location')
-PROJECT=$(shell yq r $(PACKAGE_DIR)/kptconfig/kpt-setter-config.yaml 'data."gcloud.core.project"')
+NAME=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.name' kptconfig/kpt-setter-config.yaml)
+LOCATION=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data.location' kptconfig/kpt-setter-config.yaml)
+PROJECT=$(shell docker run --rm -v "${PACKAGE_DIR}/":/workdir mikefarah/yq:4 e '.data."gcloud.core.project"' kptconfig/kpt-setter-config.yaml)
+
 
 # All Google Cloud resources must have a valid name, the most strict requirement is
 # $NAME-cnrm-system must be a valid service account name, so $NAME should be no


### PR DESCRIPTION
Fix #319

Because it requires docker installation with kpt 1.0+, so we can naturally use docker image yq v4.