### PR TITLE
fix(katib, pipelines): Use KFP 1.8.1-rc.0, and enable katib in user namespaces

### DIFF
--- a/kubeflow/apps/pipelines/pull-upstream.sh
+++ b/kubeflow/apps/pipelines/pull-upstream.sh
@@ -17,7 +17,7 @@
 set -ex
 
 # TODO: Use kubeflow/pipelines once https://github.com/kubeflow/pipelines/pull/6595 is resolved.
-export KUBEFLOW_PIPELINES_VERSION=1.8.0
+export KUBEFLOW_PIPELINES_VERSION=1.8.1-rc.0
 export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
 # export KUBEFLOW_PIPELINES_VERSION=upgradekpt # Other attempted branches: krmignore, kubeflow14
 # export KUBEFLOW_PIPELINES_REPO=https://github.com/zijianjoy/pipelines.git

--- a/kubeflow/apps/profiles/patches/namespace-labels.yaml
+++ b/kubeflow/apps/profiles/patches/namespace-labels.yaml
@@ -18,6 +18,7 @@
 #    Profile controller will enforce flag removal, but not enforce value replacement.
 #   
 katib-metricscollector-injection: 'enabled'
+katib.kubeflow.org/metrics-collector-injection: 'enabled'
 serving.kubeflow.org/inferenceservice: 'enabled'
 pipelines.kubeflow.org/enabled: 'true'
 app.kubernetes.io/part-of: 'kubeflow-profile'


### PR DESCRIPTION
Related issues:

https://github.com/kubeflow/pipelines/issues/7336

I need to add a missing katib enabled annotation to user namespace in order to be able to create AutoML experiment.