### PR TITLE
kserve: Switch from KFServing to KServe for default deployment. Fix #353

### DIFF
--- a/kubeflow/config.yaml
+++ b/kubeflow/config.yaml
@@ -116,11 +116,13 @@ components:
 - common/knative
 
 # KFServing
+# Migrated from KFServing to KServe since Kubeflow 1.5
+# Don't install both KFServing and KServe, it will cause problems using either one.
 # dependencies: [ common/knative ]
-- apps/kfserving
+# - apps/kfserving
 
 # KServe
-# dependencies: [ common/knative, apps/kfserving ]
+# dependencies: [ common/knative ]
 - contrib/kserve
 
 # Katib

--- a/kubeflow/contrib/kserve/cluster-role.yaml
+++ b/kubeflow/contrib/kserve/cluster-role.yaml
@@ -19,7 +19,7 @@ metadata: # kpt-merge: /kubeflow-kserve-edit
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kfserving-admin: "true"
 rules:
 - apiGroups:
-  - serving.kubeflow.org
+  - serving.kserve.io
   resources:
   - inferenceservices
   verbs:
@@ -60,7 +60,7 @@ metadata: # kpt-merge: /kubeflow-kserve-view
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
 rules:
 - apiGroups:
-  - serving.kubeflow.org
+  - serving.kserve.io
   resources:
   - inferenceservices
   verbs:

--- a/kubeflow/contrib/kserve/kustomization.yaml
+++ b/kubeflow/contrib/kserve/kustomization.yaml
@@ -7,12 +7,12 @@ commonLabels:
   app.kubernetes.io/name: kserve
 resources:
 - models-web-app
-- kserve/upstream
-- cluster-role.yaml
+- kserve/upstream/kserve_kubeflow.yaml
+# - cluster-role.yaml
 # - web-app-authorization-policy.yaml
 patchesStrategicMerge:
 - patches/statefulset.yaml
-- patches/namespace.yaml
+# - patches/namespace.yaml
 - patches/web-app-sidecar.yaml
 - web-app-authorization-policy.yaml
 patchesJson6902:
@@ -21,13 +21,20 @@ patchesJson6902:
     version: v1beta1
     kind: VirtualService
     name: kserve-models-web-app
-    namespace: kserve
+    namespace: kubeflow
   path: patches/web-app-vsvc.yaml
+- target:
+    group: cert-manager.io
+    version: v1alpha2
+    kind: Certificate
+    name: serving-cert
+    namespace: kubeflow
+  path: patches/webhook-certificate.yaml
 - target:
     version: v1
     kind: ConfigMap
     name: kserve-config
-    namespace: kserve
+    namespace: kubeflow
   path: patches/config-param.yaml
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubeflow/contrib/kserve/patches/statefulset.yaml
+++ b/kubeflow/contrib/kserve/patches/statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata: # kpt-merge: kserve/kserve-controller-manager
   name: kserve-controller-manager
-  namespace: kserve
+  namespace: kubeflow
 spec:
   template:
     metadata:

--- a/kubeflow/contrib/kserve/patches/web-app-sidecar.yaml
+++ b/kubeflow/contrib/kserve/patches/web-app-sidecar.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: kserve/kserve-models-web-app
   name: kserve-models-web-app
-  namespace: kserve
+  namespace: kubeflow
 spec:
   template:
     metadata:

--- a/kubeflow/contrib/kserve/patches/web-app-vsvc.yaml
+++ b/kubeflow/contrib/kserve/patches/web-app-vsvc.yaml
@@ -4,3 +4,6 @@
     host: kserve-models-web-app.kubeflow.svc.cluster.local
     port:
       number: 80
+- op: replace
+  path: /spec/http/0/match/0/uri/prefix
+  value: /models/

--- a/kubeflow/contrib/kserve/patches/webhook-certificate.yaml
+++ b/kubeflow/contrib/kserve/patches/webhook-certificate.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/commonName
+  value: kserve-webhook-server-service.kubeflow.svc
+- op: replace
+  path: /spec/dnsNames/0
+  value: kserve-webhook-server-service.kubeflow.svc


### PR DESCRIPTION
Fix #353

In this PR, we have started to use KServe as the default component for deployment. But I still keep the option open for users to choose between KFServing and KServe.

Make sure to use either KFServing or KServe by commenting/uncommenting corresponding items in `config.yaml`, but not to use both. Because it will cause conflict between these two services.

A sample pipeline step which uses KServe:

```
def create_kserve_task(model_name, model_namespace, tfjob_op, model_volume_op):

    inference_service = '''
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: {}
  namespace: {}
  annotations:
    "sidecar.istio.io/inject": "false"
spec:
  predictor:
    tensorflow:
      storageUri: "pvc://{}/"
'''.format(model_name, model_namespace, str(model_volume_op.outputs["name"]))

    kserve_launcher_op = components.load_component_from_url(
        'https://raw.githubusercontent.com/kubeflow/pipelines/master/components/kserve/component.yaml')
    kserve_launcher_op(action="apply", inferenceservice_yaml=inference_service).after(tfjob_op)
```