### PR TITLE
cloudsql: Use a shorter cloudsql service account name to allow longer Kubeflow name

### DIFF
--- a/kubeflow/apps/pipelines/cloudsql/cnrm/iam.yaml
+++ b/kubeflow/apps/pipelines/cloudsql/cnrm/iam.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   memberFrom:
     serviceAccountRef:
-      name: KUBEFLOW-NAME-kfp-cloudsql # kpt-set: ${name}-kfp-cloudsql
+      name: KUBEFLOW-NAME-sql # kpt-set: ${name}-sql
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     external: projects/PROJECT # kpt-set: projects/${gcloud.core.project}
@@ -22,4 +22,4 @@ spec:
   resourceRef:
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
-    name: KUBEFLOW-NAME-kfp-cloudsql # kpt-set: ${name}-kfp-cloudsql
+    name: KUBEFLOW-NAME-sql # kpt-set: ${name}-sql

--- a/kubeflow/apps/pipelines/cloudsql/cnrm/proxy-gsa.yaml
+++ b/kubeflow/apps/pipelines/cloudsql/cnrm/proxy-gsa.yaml
@@ -15,6 +15,6 @@
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
-  name: KUBEFLOW-NAME-kfp-cloudsql # kpt-set: ${name}-kfp-cloudsql
+  name: KUBEFLOW-NAME-sql # kpt-set: ${name}-sql
 spec:
   description: Kubeflow Pipelines CloudSQL proxy Google service account

--- a/kubeflow/apps/pipelines/cloudsql/proxy/workload-identity-binding-patch.yaml
+++ b/kubeflow/apps/pipelines/cloudsql/proxy/workload-identity-binding-patch.yaml
@@ -17,4 +17,4 @@ kind: ServiceAccount
 metadata:
   name: kubeflow-pipelines-cloudsql-proxy
   annotations:
-    iam.gke.io/gcp-service-account: KUBEFLOW-NAME-kfp-cloudsql@PROJECT.iam.gserviceaccount.com # kpt-set: ${name}-kfp-cloudsql@${gcloud.core.project}.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: KUBEFLOW-NAME-sql@PROJECT.iam.gserviceaccount.com # kpt-set: ${name}-sql@${gcloud.core.project}.iam.gserviceaccount.com


### PR DESCRIPTION
fix the name length restriction #358