### PR TITLE
kserve: Use correct configuration for showing model-web-apps from kserve on central dashboard

### DIFF
--- a/kubeflow/apps/centraldashboard/kustomization.yaml
+++ b/kubeflow/apps/centraldashboard/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
 resources:
-  # Uncomment this line for kfserving
-  # - upstream/overlays/istio
-  # Uncomment this line for kserve
-  - upstream/overlays/kserve
+# Uncomment this line for kfserving
+# - upstream/overlays/istio
+# Uncomment this line for kserve
+- upstream/overlays/kserve
 patchesStrategicMerge:
-  - deployment-patch.yaml
+- deployment-patch.yaml

--- a/kubeflow/apps/centraldashboard/kustomization.yaml
+++ b/kubeflow/apps/centraldashboard/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
 resources:
-- upstream/overlays/istio
+  # Uncomment this line for kfserving
+  # - upstream/overlays/istio
+  # Uncomment this line for kserve
+  - upstream/overlays/kserve
 patchesStrategicMerge:
-- deployment-patch.yaml
+  - deployment-patch.yaml

--- a/kubeflow/config.yaml
+++ b/kubeflow/config.yaml
@@ -118,6 +118,7 @@ components:
 # KFServing
 # Migrated from KFServing to KServe since Kubeflow 1.5
 # Don't install both KFServing and KServe, it will cause problems using either one.
+# If you want to use KFServing, also checkout the kubeflow/apps/centraldashboard/kustomization.yaml file for instruction.
 # dependencies: [ common/knative ]
 # - apps/kfserving
 

--- a/kubeflow/contrib/kserve/kustomization.yaml
+++ b/kubeflow/contrib/kserve/kustomization.yaml
@@ -17,13 +17,6 @@ patchesStrategicMerge:
 - web-app-authorization-policy.yaml
 patchesJson6902:
 - target:
-    group: networking.istio.io
-    version: v1beta1
-    kind: VirtualService
-    name: kserve-models-web-app
-    namespace: kubeflow
-  path: patches/web-app-vsvc.yaml
-- target:
     group: cert-manager.io
     version: v1alpha2
     kind: Certificate

--- a/kubeflow/contrib/kserve/patches/web-app-vsvc.yaml
+++ b/kubeflow/contrib/kserve/patches/web-app-vsvc.yaml
@@ -1,9 +1,0 @@
-- op: replace
-  path: /spec/http/0/route/0/destination
-  value:
-    host: kserve-models-web-app.kubeflow.svc.cluster.local
-    port:
-      number: 80
-- op: replace
-  path: /spec/http/0/match/0/uri/prefix
-  value: /models/


### PR DESCRIPTION
Fix https://github.com/kubeflow/manifests/issues/2180

1. Central dashboard should have used the upstream/overlays/kserve.
2. Provide an option to switch to kfserving overlay on central dashboard.
3. Remove a previous patch which is conflicting with virtual service prefix set by kserve.