### PR TITLE
Move `RequestAuthentication` policy creation to `iap-enabler` for gitops friendliness

### DIFF
--- a/kubeflow/common/iap-ingress/base/config-map.yaml
+++ b/kubeflow/common/iap-ingress/base/config-map.yaml
@@ -55,6 +55,8 @@ data:
     [ -z ${SERVICE} ] && echo Error SERVICE must be set && exit 1
     [ -z ${INGRESS_NAME} ] && echo Error INGRESS_NAME must be set && exit 1
 
+    __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
     PROJECT=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
     if [ -z ${PROJECT} ]; then
       echo Error unable to fetch PROJECT from compute metadata
@@ -100,10 +102,8 @@ data:
       echo BACKEND_ID=${BACKEND_ID}
 
       JWT_AUDIENCE="/projects/${PROJECT_NUM}/global/backendServices/${BACKEND_ID}"
-      
-      # Use kubectl patch.
-      echo patch JWT audience: ${JWT_AUDIENCE}
-      kubectl patch RequestAuthentication ingress-jwt -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/jwtRules/0/audiences/0", "value": "'${JWT_AUDIENCE}'"}]'
+      echo "Upsert RequestAuthentication with JWT audience: ${JWT_AUDIENCE}"
+      sed "s|TO_BE_PATCHED|${JWT_AUDIENCE}|" ${__dir}/policy.yaml | kubectl apply -n ${NAMESPACE} -f -
 
       echo "Clearing lock on service annotation"
       kubectl patch svc "${SERVICE}" -n istio-system -p "{\"metadata\": { \"annotations\": {\"backendlock\": \"\" }}}"
@@ -181,6 +181,22 @@ data:
       echo "Backend updated successfully. Waiting 1 hour before updating again."
       sleep 3600
     done
+  policy.yaml: |
+    apiVersion: security.istio.io/v1beta1
+    kind: RequestAuthentication
+    metadata:
+      name: ingress-jwt
+    spec:
+      selector:
+        matchLabels:
+          app: istio-ingressgateway
+      jwtRules:
+      - audiences:
+        - TO_BE_PATCHED
+        issuer: https://cloud.google.com/iap
+        jwksUri: https://www.gstatic.com/iap/verify/public_key-jwk
+        fromHeaders:
+        - name: x-goog-iap-jwt-assertion  
 kind: ConfigMap
 metadata:
   name: envoy-config

--- a/kubeflow/common/iap-ingress/base/config-map.yaml
+++ b/kubeflow/common/iap-ingress/base/config-map.yaml
@@ -181,22 +181,6 @@ data:
       echo "Backend updated successfully. Waiting 1 hour before updating again."
       sleep 3600
     done
-  policy.yaml: |
-    apiVersion: security.istio.io/v1beta1
-    kind: RequestAuthentication
-    metadata:
-      name: ingress-jwt
-    spec:
-      selector:
-        matchLabels:
-          app: istio-ingressgateway
-      jwtRules:
-      - audiences:
-        - TO_BE_PATCHED
-        issuer: https://cloud.google.com/iap
-        jwksUri: https://www.gstatic.com/iap/verify/public_key-jwk
-        fromHeaders:
-        - name: x-goog-iap-jwt-assertion  
 kind: ConfigMap
 metadata:
   name: envoy-config

--- a/kubeflow/common/iap-ingress/base/config-map.yaml
+++ b/kubeflow/common/iap-ingress/base/config-map.yaml
@@ -103,7 +103,7 @@ data:
 
       JWT_AUDIENCE="/projects/${PROJECT_NUM}/global/backendServices/${BACKEND_ID}"
       echo "Upsert RequestAuthentication with JWT audience: ${JWT_AUDIENCE}"
-      sed "s|TO_BE_PATCHED|${JWT_AUDIENCE}|" ${__dir}/policy.yaml | kubectl apply -n ${NAMESPACE} -f -
+      sed "s|JWT_AUDIENCE|${JWT_AUDIENCE}|" ${__dir}/policy.yaml | kubectl apply -n ${NAMESPACE} -f -
 
       echo "Clearing lock on service annotation"
       kubectl patch svc "${SERVICE}" -n istio-system -p "{\"metadata\": { \"annotations\": {\"backendlock\": \"\" }}}"

--- a/kubeflow/common/iap-ingress/base/kustomization.yaml
+++ b/kubeflow/common/iap-ingress/base/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
 - deployment.yaml
 - iap-ingress-config.yaml
 - ingress.yaml
-- policy.yaml
 - service-account.yaml
 - service.yaml
 - stateful-set.yaml

--- a/kubeflow/common/iap-ingress/base/kustomization.yaml
+++ b/kubeflow/common/iap-ingress/base/kustomization.yaml
@@ -26,6 +26,11 @@ images:
 - name: gcr.io/ml-pipeline/cloud-solutions-group/esp-sample-app
   newName: gcr.io/ml-pipeline/cloud-solutions-group/esp-sample-app
   newTag: 1.0.0
+configMapGenerator:
+  - name: envoy-config
+    behavior: merge
+    files:
+      - policy.yaml
 # TODO(Bobgy): migrate kustomize vars to kpt setters?
 vars:
 - name: appName

--- a/kubeflow/common/iap-ingress/base/policy.yaml
+++ b/kubeflow/common/iap-ingress/base/policy.yaml
@@ -8,7 +8,7 @@ spec:
       app: istio-ingressgateway
   jwtRules:
   - audiences:
-    - TO_BE_PATCHED
+    - JWT_AUDIENCE
     issuer: https://cloud.google.com/iap
     jwksUri: https://www.gstatic.com/iap/verify/public_key-jwk
     fromHeaders:


### PR DESCRIPTION
# Problem

In my gitops setup I was facing a race condition between `Fluxcd` and `iap-enabler` where they were both updating the `ingress-jwt` RequestAuthentication resource:

- Fluxcd creates/updates the `ingress-jwt` RequestAuthentication resource without the audience (TO_BE_PATCHED)
- `iap-enabler` resolves the backend id and patches the `ingress-jwt` audience

# Solution

Move `ingress-jwt` RequestAuthentication creation logic to `iap-enabler`.

- Move `policy.yaml` from Kustomize resources list to `envoy-config` ConfigMap
- Refactor `setup_backend.sh` to replace `TO_BE_PATCHED` with the correct audience and apply `policy.yaml` to create/update `ingress-jwt`
