### PR TITLE
Upgrade ASM to v1.13

### DIFF
--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -3,15 +3,15 @@
 # https://cloud.google.com/service-mesh/docs/unified-install/anthos-service-mesh-prerequisites
 # To upgrade your current ASM instance, please follow instructions:
 # https://cloud.google.com/service-mesh/docs/unified-install/plan-upgrade
-# 
+#
 # Get a list of stable versions of asmcli and config by running this command
 # curl https://storage.googleapis.com/csm-artifacts/asm/ASMCLI_VERSIONS
-# For example: 1.13.4-asm.4+config2:install_asm_1.13.4-asm.4-config2
+# For example: 1.13.4-asm.4+config2:asmcli
 # The part before colon symbol should be used for ASM_PACKAGE_VERSION.
 # The part after colon symbol should be used for ASMCLI_SCRIPT_VERSION.
 
 ASM_PACKAGE_VERSION=1.13.4-asm.4+config2
-ASMCLI_SCRIPT_VERSION=asmcli_1.13.4-asm.4-confi2
+ASMCLI_SCRIPT_VERSION=asmcli
 
 # The name of the context for your Kubeflow cluster
 PACKAGE_DIR?=$(shell pwd)/..
@@ -38,7 +38,7 @@ download-asm-package:
 	tar -xf asm.tar.gz --strip-components=1 -C package 
 
 .PHONY: install-asm
-install-asm:
+install-asm: download-asmcli download-asm-package
 	./asmcli install \
 	--project_id $(PROJECT) \
 	--cluster_name $(NAME) \
@@ -52,7 +52,7 @@ install-asm:
 	--verbose
 
 .PHONY: apply
-apply: hydrate install-asm
+apply: install-asm
 
 .PHONY: hydrate
 hydrate: download-asmcli download-asm-package asmcli-validate asmcli-precheck
@@ -72,7 +72,7 @@ asmcli-validate:
 
 .PHONY: asmcli-precheck
 asmcli-precheck:
-	pushd $(UPSTREAM) && ./istioctl experimental precheck && popd
+	pushd ${UPSTREAM} && ./istioctl experimental precheck && popd
 # Note about install gateways
 # https://cloud.google.com/service-mesh/docs/unified-install/install#install_gateways
 

--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -9,13 +9,12 @@ INSTALL_ASM_SCRIPT_VERSION=asmcli_1.13
 
 # Use of older versions of ASM is not recommended and will not be supported 
 # in the future: https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases
+# ASM Upgrade Guide: Check out README.md of the same directory.
 # Get a list of stable versions prior to v1.12 of install_asm and config by running this command
 # curl https://storage.googleapis.com/csm-artifacts/asm/STABLE_VERSIONS
 # For example: 1.9.2-asm.1+config4:install_asm_1.9.2-asm.1-config4
 # The part before colon symbol should be used for ASM_PACKAGE_VERSION.
 # The part after colon symbol should be used for INSTALL_ASM_SCRIPT_VERSION.
-# ASM Upgrade Guide: Check out README.md of the same directory.
-# curl https://storage.googleapis.com/csm-artifacts/asm/STABLE_VERSIONS
 
 # The name of the context for your Kubeflow cluster
 PACKAGE_DIR?=$(shell pwd)/..

--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -42,7 +42,7 @@ download-asm-package:
 	tar -xf asm.tar.gz --strip-components=1 -C package 
 
 .PHONY: install-asm
-install-asm-legacy: download-asmcli download-asm-package
+install-asm: download-asmcli download-asm-package
 	./asmcli install \
 	--project_id $(PROJECT) \
 	--cluster_name $(NAME) \

--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -3,18 +3,15 @@
 # https://cloud.google.com/service-mesh/docs/unified-install/anthos-service-mesh-prerequisites
 # To upgrade your current ASM instance, please follow instructions:
 # https://cloud.google.com/service-mesh/docs/unified-install/plan-upgrade
+# 
+# Get a list of stable versions of asmcli and config by running this command
+# curl https://storage.googleapis.com/csm-artifacts/asm/ASMCLI_VERSIONS
+# For example: 1.13.4-asm.4+config2:install_asm_1.13.4-asm.4-config2
+# The part before colon symbol should be used for ASM_PACKAGE_VERSION.
+# The part after colon symbol should be used for ASMCLI_SCRIPT_VERSION.
 
 ASM_PACKAGE_VERSION=1.13.4-asm.4+config2
-INSTALL_ASM_SCRIPT_VERSION=asmcli_1.13
-
-# Use of older versions of ASM is not recommended and will not be supported 
-# in the future: https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases
-# ASM Upgrade Guide: Check out README.md of the same directory.
-# Get a list of stable versions prior to v1.12 of install_asm and config by running this command
-# curl https://storage.googleapis.com/csm-artifacts/asm/STABLE_VERSIONS
-# For example: 1.9.2-asm.1+config4:install_asm_1.9.2-asm.1-config4
-# The part before colon symbol should be used for ASM_PACKAGE_VERSION.
-# The part after colon symbol should be used for INSTALL_ASM_SCRIPT_VERSION.
+ASMCLI_SCRIPT_VERSION=asmcli_1.13.4-asm.4-confi2
 
 # The name of the context for your Kubeflow cluster
 PACKAGE_DIR?=$(shell pwd)/..
@@ -28,7 +25,7 @@ UPSTREAM=upstream
 
 .PHONY: download-asmcli
 download-asmcli: 
-	curl https://storage.googleapis.com/csm-artifacts/asm/$(INSTALL_ASM_SCRIPT_VERSION) > asmcli;
+	curl https://storage.googleapis.com/csm-artifacts/asm/$(ASMCLI_SCRIPT_VERSION) > asmcli;
 	chmod +x asmcli
 
 .PHONY: download-asm-package
@@ -41,7 +38,7 @@ download-asm-package:
 	tar -xf asm.tar.gz --strip-components=1 -C package 
 
 .PHONY: install-asm
-install-asm: download-asmcli download-asm-package
+install-asm:
 	./asmcli install \
 	--project_id $(PROJECT) \
 	--cluster_name $(NAME) \
@@ -55,15 +52,10 @@ install-asm: download-asmcli download-asm-package
 	--verbose
 
 .PHONY: apply
-apply: install-asm
+apply: hydrate install-asm
 
 .PHONY: hydrate
-hydrate: # download-asmcli asmcli-validate asmcli-precheck
-# There is no hydration for ASM, it is taken care by install_asm/asmcli. 
-# In the future, we will migrate to use asmcli, you can validate readiness using following commands.
-# make asmcli-validate 
-# make asmcli-precheck
-# Note: Require existence of a cluster before running the commands above.
+hydrate: download-asmcli download-asm-package asmcli-validate asmcli-precheck
 
 .PHONY: asmcli-validate
 asmcli-validate:
@@ -73,7 +65,7 @@ asmcli-validate:
 	--cluster_location $(LOCATION) \
 	--output_dir $(UPSTREAM) \
 	--ca mesh_ca \
-	--custom_overlay ./$(UPSTREAM)/asm/istio/options/iap-operator.yaml \
+	--custom_overlay ./package/asm/istio/options/iap-operator.yaml \
 	--custom_overlay ./options/ingressgateway-iap.yaml \
 	--option legacy-default-ingressgateway \
 	--verbose
@@ -84,26 +76,3 @@ asmcli-precheck:
 # Note about install gateways
 # https://cloud.google.com/service-mesh/docs/unified-install/install#install_gateways
 
-.PHONY: download-install-asm-script-legacy
-download-install-asm-script-legacy:
-	curl https://storage.googleapis.com/csm-artifacts/asm/$(INSTALL_ASM_SCRIPT_VERSION) > install_asm;
-	chmod +x install_asm
-# Official documentation of downloading install_asm: https://cloud.google.com/service-mesh/docs/scripted-install/asm-onboarding#downloading_the_script
-# It cannot control the patch version so we won't use this approach for now.
-# cd ./asm && { \
-# 	curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_1.9 > install_asm; \
-# 	curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_1.9.sha256 > install_asm.sha256; \
-# 	sha256sum -c --ignore-missing install_asm.sha256; \
-# 	chmod +x install_asm; \
-# 	cd -;}
-
-.PHONY: install-asm-legacy
-install-asm-legacy: download-install-asm-script-legacy download-asm-package
-	./install_asm \
-	--project_id $(PROJECT) \
-	--cluster_name $(NAME) \
-	--cluster_location $(LOCATION) \
-	--mode install \
-	--enable_all \
-	--custom_overlay ./package/asm/istio/options/iap-operator.yaml \
-	--custom_overlay ./options/ingressgateway-iap.yaml

--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -6,12 +6,12 @@
 #
 # Get a list of stable versions of asmcli and config by running this command
 # curl https://storage.googleapis.com/csm-artifacts/asm/ASMCLI_VERSIONS
-# For example: 1.13.4-asm.4+config2:asmcli
+# For example: 1.13.2-asm.5+config2:asmcli_1.13.2-asm.5-config2
 # The part before colon symbol should be used for ASM_PACKAGE_VERSION.
 # The part after colon symbol should be used for ASMCLI_SCRIPT_VERSION.
 
-ASM_PACKAGE_VERSION=1.13.4-asm.4+config2
-ASMCLI_SCRIPT_VERSION=asmcli
+ASM_PACKAGE_VERSION=1.13.2-asm.5+config2
+ASMCLI_SCRIPT_VERSION=asmcli_1.13.2-asm.5-config2
 
 # The name of the context for your Kubeflow cluster
 PACKAGE_DIR?=$(shell pwd)/..

--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -1,11 +1,21 @@
-# Get a list of stable versions of install_asm and config by running this command
+# ASM was upgraded to v1.13 in Kubeflow for GCP v1.5.1
+# ASM changed the installation process begining v1.12. See details:
+# https://cloud.google.com/service-mesh/docs/unified-install/anthos-service-mesh-prerequisites
+# To upgrade your current ASM instance, please follow instructions:
+# https://cloud.google.com/service-mesh/docs/unified-install/plan-upgrade
+
+ASM_PACKAGE_VERSION=1.13.4-asm.4+config2
+INSTALL_ASM_SCRIPT_VERSION=asmcli_1.13
+
+# Use of older versions of ASM is not recommended and will not be supported 
+# in the future: https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases
+# Get a list of stable versions prior to v1.12 of install_asm and config by running this command
 # curl https://storage.googleapis.com/csm-artifacts/asm/STABLE_VERSIONS
 # For example: 1.9.2-asm.1+config4:install_asm_1.9.2-asm.1-config4
 # The part before colon symbol should be used for ASM_PACKAGE_VERSION.
 # The part after colon symbol should be used for INSTALL_ASM_SCRIPT_VERSION.
-ASM_PACKAGE_VERSION=1.10.4-asm.6+config2
-INSTALL_ASM_SCRIPT_VERSION=install_asm_1.10.4-asm.6-config2
 # ASM Upgrade Guide: Check out README.md of the same directory.
+# curl https://storage.googleapis.com/csm-artifacts/asm/STABLE_VERSIONS
 
 # The name of the context for your Kubeflow cluster
 PACKAGE_DIR?=$(shell pwd)/..
@@ -17,18 +27,10 @@ LOCATION=$(shell $(YQ) e '.data.location' kptconfig/kpt-setter-config.yaml)
 
 UPSTREAM=upstream
 
-.PHONY: download-install-asm-script
-download-install-asm-script:
-	curl https://storage.googleapis.com/csm-artifacts/asm/$(INSTALL_ASM_SCRIPT_VERSION) > install_asm;
-	chmod +x install_asm
-# Official documentation of downloading install_asm: https://cloud.google.com/service-mesh/docs/scripted-install/asm-onboarding#downloading_the_script
-# It cannot control the patch version so we won't use this approach for now.
-# cd ./asm && { \
-# 	curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_1.9 > install_asm; \
-# 	curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_1.9.sha256 > install_asm.sha256; \
-# 	sha256sum -c --ignore-missing install_asm.sha256; \
-# 	chmod +x install_asm; \
-# 	cd -;}
+.PHONY: download-asmcli
+download-asmcli: 
+	curl https://storage.googleapis.com/csm-artifacts/asm/$(INSTALL_ASM_SCRIPT_VERSION) > asmcli;
+	chmod +x asmcli
 
 .PHONY: download-asm-package
 download-asm-package:
@@ -40,16 +42,18 @@ download-asm-package:
 	tar -xf asm.tar.gz --strip-components=1 -C package 
 
 .PHONY: install-asm
-install-asm: download-install-asm-script download-asm-package
-	./install_asm \
+install-asm-legacy: download-asmcli download-asm-package
+	./asmcli install \
 	--project_id $(PROJECT) \
 	--cluster_name $(NAME) \
 	--cluster_location $(LOCATION) \
-	--mode install \
+	--output_dir $(UPSTREAM) \
 	--enable_all \
+	--ca mesh_ca \
 	--custom_overlay ./package/asm/istio/options/iap-operator.yaml \
-	--custom_overlay ./options/ingressgateway-iap.yaml
-
+	--custom_overlay ./options/ingressgateway-iap.yaml \
+	--option legacy-default-ingressgateway \
+	--verbose
 
 .PHONY: apply
 apply: install-asm
@@ -61,13 +65,6 @@ hydrate: # download-asmcli asmcli-validate asmcli-precheck
 # make asmcli-validate 
 # make asmcli-precheck
 # Note: Require existence of a cluster before running the commands above.
-
-# Commands below are for asmcli, asmcli is in alpha state, we plan to migrate from install_asm to asmcli when ready.
-.PHONY: download-asmcli
-download-asmcli: 
-	curl https://storage.googleapis.com/csm-artifacts/asm/asmcli_alpha > asmcli
-	curl https://storage.googleapis.com/csm-artifacts/asm/asmcli_alpha.sha256 > asmcli.sha256
-	chmod +x asmcli
 
 .PHONY: asmcli-validate
 asmcli-validate:
@@ -82,25 +79,32 @@ asmcli-validate:
 	--option legacy-default-ingressgateway \
 	--verbose
 
-
-.PHONY: asmcli-install
-asmcli-install: download-asmcli
-# --fleet_id is optional. If not specified, use project_id
-	./asmcli install \
-	--project_id $(PROJECT) \
-	--cluster_name $(NAME) \
-	--cluster_location $(LOCATION) \
-	--output_dir $(UPSTREAM) \
-	--enable_all \
-	--ca mesh_ca \
-	--custom_overlay ./$(UPSTREAM)/asm/istio/options/iap-operator.yaml \
-	--custom_overlay ./options/ingressgateway-iap.yaml \
-	--option legacy-default-ingressgateway \
-	--verbose
-
 .PHONY: asmcli-precheck
 asmcli-precheck:
 	pushd $(UPSTREAM) && ./istioctl experimental precheck && popd
-
 # Note about install gateways
 # https://cloud.google.com/service-mesh/docs/unified-install/install#install_gateways
+
+.PHONY: download-install-asm-script-legacy
+download-install-asm-script-legacy:
+	curl https://storage.googleapis.com/csm-artifacts/asm/$(INSTALL_ASM_SCRIPT_VERSION) > install_asm;
+	chmod +x install_asm
+# Official documentation of downloading install_asm: https://cloud.google.com/service-mesh/docs/scripted-install/asm-onboarding#downloading_the_script
+# It cannot control the patch version so we won't use this approach for now.
+# cd ./asm && { \
+# 	curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_1.9 > install_asm; \
+# 	curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_1.9.sha256 > install_asm.sha256; \
+# 	sha256sum -c --ignore-missing install_asm.sha256; \
+# 	chmod +x install_asm; \
+# 	cd -;}
+
+.PHONY: install-asm-legacy
+install-asm-legacy: download-install-asm-script-legacy download-asm-package
+	./install_asm \
+	--project_id $(PROJECT) \
+	--cluster_name $(NAME) \
+	--cluster_location $(LOCATION) \
+	--mode install \
+	--enable_all \
+	--custom_overlay ./package/asm/istio/options/iap-operator.yaml \
+	--custom_overlay ./options/ingressgateway-iap.yaml

--- a/kubeflow/asm/README.md
+++ b/kubeflow/asm/README.md
@@ -7,7 +7,7 @@
 ### Documentations
 
 * [Official guide to upgrade ASM](https://cloud.google.com/service-mesh/docs/upgrade-path-old-versions-gke)
-* [Kubeflow guide to upgreade ASM](https://www.kubeflow.org/docs/distributions/gke/deploy/upgrade/#upgrade-asm-anthos-service-mesh)
+* [Kubeflow guide to upgrade ASM](https://www.kubeflow.org/docs/distributions/gke/deploy/upgrade/#upgrade-asm-anthos-service-mes)
 * [Official ASM instalation guide](https://cloud.google.com/service-mesh/docs/scripted-install/gke-install)
 * [Integrate ASM with IAP](https://cloud.google.com/service-mesh/docs/iap-integration)
 

--- a/kubeflow/asm/README.md
+++ b/kubeflow/asm/README.md
@@ -6,11 +6,12 @@
 
 ### Documentations
 
-* [Kubeflow upgrade ASM guide](https://www.kubeflow.org/docs/distributions/gke/deploy/upgrade/#upgrade-asm-anthos-service-mesh)
-* [Official ASM instalation guide with install_asm approach](https://cloud.google.com/service-mesh/docs/scripted-install/gke-install)
-* [Integrate ASM with IAP](https://cloud.google.com/service-mesh/docs/iap-integration )
+* [Official guide to upgrade ASM](https://cloud.google.com/service-mesh/docs/upgrade-path-old-versions-gke)
+* [Kubeflow guide to upgreade ASM](https://www.kubeflow.org/docs/distributions/gke/deploy/upgrade/#upgrade-asm-anthos-service-mesh)
+* [Official ASM instalation guide](https://cloud.google.com/service-mesh/docs/scripted-install/gke-install)
+* [Integrate ASM with IAP](https://cloud.google.com/service-mesh/docs/iap-integration)
 
-### Upgrade steps
+### Upgrade steps for legacy ASM installation approach
 
 You can upgrade ASM by first installing ASM tools' package, and installing new ASM to cluster. Migrate existing workload to new ASM, then deprecate the old ASM:
 

--- a/kubeflow/asm/README.md
+++ b/kubeflow/asm/README.md
@@ -1,48 +1,76 @@
 # Anthos Service Mesh (ASM)
 
-[Anthos Service Mesh introduction](https://cloud.google.com/anthos/service-mesh)
+Introduction to ASM: [Anthos Service Mesh](https://cloud.google.com/anthos/service-mesh)
 
 ## Upgrade ASM
 
-### Documentations
+### Reference guidelines
 
 * [Official guide to upgrade ASM](https://cloud.google.com/service-mesh/docs/upgrade-path-old-versions-gke)
 * [Kubeflow guide to upgrade ASM](https://www.kubeflow.org/docs/distributions/gke/deploy/upgrade/#upgrade-asm-anthos-service-mes)
-* [Official ASM instalation guide](https://cloud.google.com/service-mesh/docs/unified-install/install-anthos-service-mesh)
+* [Official ASM installation guide](https://cloud.google.com/service-mesh/docs/unified-install/install-anthos-service-mesh)
 * [Integrate ASM with IAP](https://cloud.google.com/service-mesh/docs/unified-install/options/iap-integration)
 
-### Upgrade steps for legacy ASM installation approach
+### Upgrade steps
 
-You can upgrade ASM by first installing ASM tools' package, and installing new ASM to cluster. Migrate existing workload to new ASM, then deprecate the old ASM:
+The following steps explain how to install a newer version of ASM, migrate Kubeflow's workloads, and deprecate the old ASM or revert the new ASM.
 
-* Get a list of stable versions of `asmcli` and `config packages` by running this command:
+1. Get a list of stable versions of `config packages` and `asmcli` by running this command:
 
     ```
     curl https://storage.googleapis.com/csm-artifacts/asm/ASMCLI_VERSIONS
     ```
+    
+    It should return a list of ASM versions that can be installed with `asmcli` tool. To install older versions, refer to [legacy instructions](deprecated/README.md). The returned list will have a format of `ASM_PACKAGE_VERSION:ASMCLI_SCRIPT_VERSION`. For example, in the following output:
 
-    For example: `1.13.2-asm.5+config2:asmcli_1.13.2-asm.5-config2`. The part before colon symbol (1.13.2-asm.5+config2) should be used for `ASM_PACKAGE_VERSION` in Makefile of current directory. The part after colon symbol (asmcli_1.13.2-asm.5-config2) should be used for `ASMCLI_SCRIPT_VERSION`.
+    ```
+    ...
+    1.13.2-asm.5+config2:asmcli_1.13.2-asm.5-config2
+    1.13.2-asm.5+config1:asmcli_1.13.2-asm.5-config1
+    1.13.2-asm.2+config2:asmcli_1.13.2-asm.2-config2
+    1.13.2-asm.2+config1:asmcli_1.13.2-asm.2-config1
+    1.13.1-asm.1+config1:asmcli_1.13.1-asm.1-config1
+    ...
+    ```
 
-* Determine the ASM version you want to upgrade, follow the instruction above to update `ASM_PACKAGE_VERSION` and `ASMCLI_SCRIPT_VERSION` in Makefile. Then run the following command under `kubeflow/common/asm` to install new ASM version.
+    record `1.13.2-asm.5+config2:asmcli_1.13.2-asm.5-config2` corresponds to:
+
+    ```
+    ASM_PACKAGE_VERSION=1.13.2-asm.5+config2
+    ASMCLI_SCRIPT_VERSION=asmcli_1.13.2-asm.5-config2
+    ```
+    
+    You need to set these variable in the [Makefile](./Makefile) inside **`kubeflow/asm/`** directory.
+
+2. After updating `ASM_PACKAGE_VERSION` and `ASMCLI_SCRIPT_VERSION` variables in the [Makefile](./Makefile), run the following command in **`kubeflow/asm/`** directory to install the chosen new ASM version:
 
     ```
     make install-asm
     ```
 
-* Update `kubeflow/env.sh` for the ASM version, this looks like format: **asm-1132-5**, and you can find the exact value in istiod pod's label as well.
-    
-    For example: You can find label `istio.io/rev: asm-1132-5` in istiod-asm-1132-5 service. Then run `source env.sh` under `kubeflow/` folder.
+3. Update `ASM_LABEL` variable in **[env.sh](../env.sh)** located in **`kubeflow/`** directory. For example, it takes value of **asm-1132-5** for ASM version 1.13.2-asm.5. 
 
-* Configure kpt setter value under `kubeflow/` for all Kubeflow components which require to set ASM namespace label:
+    You can also find this value in istiod pod's label: `istio.io/rev: asm-1132-5` in istiod-asm-1132-5 service. 
+    
+    Then run the following command in **`kubeflow/`** directory:
+
+    ```
+    source env.sh
+    ``` 
+
+4. Configure kpt setter values for all Kubeflow components that require new ASM namespace label by running the following command in **`kubeflow/`** directory:
 
     ```
     bash kpt-set.sh
     ```
 
-* Follow official doc [Deploy and Redeploy workloads](https://cloud.google.com/service-mesh/docs/unified-install/upgrade#deploying_and_redeploying_workloads) to migrate workloads in each namespace, including user namespace created in [Kubeflow multi-tenancy](https://www.kubeflow.org/docs/components/multi-tenancy/getting-started/). In the case of Kubeflow cluster deployment, you can rerun `make apply` under `kubeflow/` directory to upgrade workloads. (Note: You can also run `make hydrate` before `make apply` to compare the difference of resource manifests.)
+5. Follow the official instructions on how to [deploy and redeploy workloads](https://cloud.google.com/service-mesh/docs/unified-install/upgrade#deploying_and_redeploying_workloads) to migrate them to a new ASM in each namespace, including user namespace created in [Kubeflow multi-tenancy](https://www.kubeflow.org/docs/components/multi-tenancy/getting-started/). In case of Kubeflow cluster deployment, you can rerun the following command in **`kubeflow/`** directory:
 
     ```
     make apply
     ```
 
-* (Optional): Deprecate old ASM by following `Complete the transistion -> Migrate` in [Deploy and Redeploy workloads](https://cloud.google.com/service-mesh/docs/unified-install/upgrade#deploying_and_redeploying_workloads).
+    > **Note:**
+    > you can also run `make hydrate` before `make apply` to compare the differences of the resource manifests.
+
+6. (Optional): **Complete the transition** to the new ASM or **Rollback** to the old ASM as instructed in [Deploy and Redeploy workloads](https://cloud.google.com/service-mesh/docs/unified-install/upgrade#deploying_and_redeploying_workloads).

--- a/kubeflow/asm/README.md
+++ b/kubeflow/asm/README.md
@@ -8,30 +8,30 @@
 
 * [Official guide to upgrade ASM](https://cloud.google.com/service-mesh/docs/upgrade-path-old-versions-gke)
 * [Kubeflow guide to upgrade ASM](https://www.kubeflow.org/docs/distributions/gke/deploy/upgrade/#upgrade-asm-anthos-service-mes)
-* [Official ASM instalation guide](https://cloud.google.com/service-mesh/docs/scripted-install/gke-install)
-* [Integrate ASM with IAP](https://cloud.google.com/service-mesh/docs/iap-integration)
+* [Official ASM instalation guide](https://cloud.google.com/service-mesh/docs/unified-install/install-anthos-service-mesh)
+* [Integrate ASM with IAP](https://cloud.google.com/service-mesh/docs/unified-install/options/iap-integration)
 
 ### Upgrade steps for legacy ASM installation approach
 
 You can upgrade ASM by first installing ASM tools' package, and installing new ASM to cluster. Migrate existing workload to new ASM, then deprecate the old ASM:
 
-* Get a list of stable versions of `install_asm` and `config packages` by running this command:
+* Get a list of stable versions of `asmcli` and `config packages` by running this command:
 
     ```
-    curl https://storage.googleapis.com/csm-artifacts/asm/STABLE_VERSIONS
+    curl https://storage.googleapis.com/csm-artifacts/asm/ASMCLI_VERSIONS
     ```
 
-    For example: `1.9.2-asm.1+config4:install_asm_1.9.2-asm.1-config4`. The part before colon symbol (1.9.2-asm.1+config4) should be used for `ASM_PACKAGE_VERSION` in Makefile of current directory.The part after colon symbol (install_asm_1.9.2-asm.1-config4) should be used for `INSTALL_ASM_SCRIPT_VERSION`.
+    For example: `1.13.4-asm.4+config2:asmcli`. The part before colon symbol (1.13.4-asm.4+config2) should be used for `ASM_PACKAGE_VERSION` in Makefile of current directory. The part after colon symbol (asmcli) should be used for `ASMCLI_SCRIPT_VERSION`.
 
-* Determine the ASM version you want to upgrade, follow the instruction above to update `ASM_PACKAGE_VERSION` and `INSTALL_ASM_SCRIPT_VERSION` in Makefile. Then run the following command under `kubeflow/common/asm` to install new ASM version.
+* Determine the ASM version you want to upgrade, follow the instruction above to update `ASM_PACKAGE_VERSION` and `ASMCLI_SCRIPT_VERSION` in Makefile. Then run the following command under `kubeflow/common/asm` to install new ASM version.
 
     ```
     make install-asm
     ```
 
-* Update `kubeflow/env.sh` for the ASM version, this looks like format: **asm-192-1**, and you can find the exact value in istiod pod's label as well.
+* Update `kubeflow/env.sh` for the ASM version, this looks like format: **asm-1134-4**, and you can find the exact value in istiod pod's label as well.
     
-    For example: You can find label `istio.io/rev: asm-192-1` in istiod-asm-192-1 service. Then run `source env.sh` under `kubeflow/` folder.
+    For example: You can find label `istio.io/rev: asm-1134-4` in istiod-asm-1134-4 service. Then run `source env.sh` under `kubeflow/` folder.
 
 * Configure kpt setter value under `kubeflow/` for all Kubeflow components which require to set ASM namespace label:
 
@@ -39,10 +39,10 @@ You can upgrade ASM by first installing ASM tools' package, and installing new A
     bash kpt-set.sh
     ```
 
-* Follow official doc [Deploy and Redeploy workloads](https://cloud.google.com/service-mesh/docs/scripted-install/gke-upgrade#deploying_and_redeploying_workloads) to migrate workloads in each namespace, including user namespace created in [Kubeflow multi-tenancy](https://www.kubeflow.org/docs/components/multi-tenancy/getting-started/). In the case of Kubeflow cluster deployment, you can rerun `make apply` under `kubeflow/` directory to upgrade workloads. (Note: You can also run `make hydrate` before `make apply` to compare the difference of resource manifests.)
+* Follow official doc [Deploy and Redeploy workloads](https://cloud.google.com/service-mesh/docs/unified-install/upgrade#deploying_and_redeploying_workloads) to migrate workloads in each namespace, including user namespace created in [Kubeflow multi-tenancy](https://www.kubeflow.org/docs/components/multi-tenancy/getting-started/). In the case of Kubeflow cluster deployment, you can rerun `make apply` under `kubeflow/` directory to upgrade workloads. (Note: You can also run `make hydrate` before `make apply` to compare the difference of resource manifests.)
 
     ```
     make apply
     ```
 
-* (Optional): Deprecate old ASM by following `Complete the transistion -> Migrate` in [Deploy and Redeploy workloads](https://cloud.google.com/service-mesh/docs/scripted-install/gke-upgrade#deploying_and_redeploying_workloads).
+* (Optional): Deprecate old ASM by following `Complete the transistion -> Migrate` in [Deploy and Redeploy workloads](https://cloud.google.com/service-mesh/docs/unified-install/upgrade#deploying_and_redeploying_workloads).

--- a/kubeflow/asm/README.md
+++ b/kubeflow/asm/README.md
@@ -40,9 +40,9 @@ The following steps explain how to install a newer version of ASM, migrate Kubef
     ASMCLI_SCRIPT_VERSION=asmcli_1.13.2-asm.5-config2
     ```
     
-    You need to set these variable in the [Makefile](./Makefile) inside **`kubeflow/asm/`** directory.
+    You need to set these variable in the **[Makefile](./Makefile)** inside **`kubeflow/asm/`** directory.
 
-2. After updating `ASM_PACKAGE_VERSION` and `ASMCLI_SCRIPT_VERSION` variables in the [Makefile](./Makefile), run the following command in **`kubeflow/asm/`** directory to install the chosen new ASM version:
+2. After updating `ASM_PACKAGE_VERSION` and `ASMCLI_SCRIPT_VERSION` variables in the **[Makefile](./Makefile)**, run the following command in **`kubeflow/asm/`** directory to install the chosen new ASM version:
 
     ```
     make install-asm

--- a/kubeflow/asm/README.md
+++ b/kubeflow/asm/README.md
@@ -21,7 +21,7 @@ You can upgrade ASM by first installing ASM tools' package, and installing new A
     curl https://storage.googleapis.com/csm-artifacts/asm/ASMCLI_VERSIONS
     ```
 
-    For example: `1.13.4-asm.4+config2:asmcli`. The part before colon symbol (1.13.4-asm.4+config2) should be used for `ASM_PACKAGE_VERSION` in Makefile of current directory. The part after colon symbol (asmcli) should be used for `ASMCLI_SCRIPT_VERSION`.
+    For example: `1.13.2-asm.5+config2:asmcli_1.13.2-asm.5-config2`. The part before colon symbol (1.13.2-asm.5+config2) should be used for `ASM_PACKAGE_VERSION` in Makefile of current directory. The part after colon symbol (asmcli_1.13.2-asm.5-config2) should be used for `ASMCLI_SCRIPT_VERSION`.
 
 * Determine the ASM version you want to upgrade, follow the instruction above to update `ASM_PACKAGE_VERSION` and `ASMCLI_SCRIPT_VERSION` in Makefile. Then run the following command under `kubeflow/common/asm` to install new ASM version.
 
@@ -29,9 +29,9 @@ You can upgrade ASM by first installing ASM tools' package, and installing new A
     make install-asm
     ```
 
-* Update `kubeflow/env.sh` for the ASM version, this looks like format: **asm-1134-4**, and you can find the exact value in istiod pod's label as well.
+* Update `kubeflow/env.sh` for the ASM version, this looks like format: **asm-1132-5**, and you can find the exact value in istiod pod's label as well.
     
-    For example: You can find label `istio.io/rev: asm-1134-4` in istiod-asm-1134-4 service. Then run `source env.sh` under `kubeflow/` folder.
+    For example: You can find label `istio.io/rev: asm-1132-5` in istiod-asm-1132-5 service. Then run `source env.sh` under `kubeflow/` folder.
 
 * Configure kpt setter value under `kubeflow/` for all Kubeflow components which require to set ASM namespace label:
 

--- a/kubeflow/asm/deprecated/Makefile
+++ b/kubeflow/asm/deprecated/Makefile
@@ -1,0 +1,106 @@
+# Get a list of stable versions of install_asm and config by running this command
+# curl https://storage.googleapis.com/csm-artifacts/asm/STABLE_VERSIONS
+# For example: 1.9.2-asm.1+config4:install_asm_1.9.2-asm.1-config4
+# The part before colon symbol should be used for ASM_PACKAGE_VERSION.
+# The part after colon symbol should be used for INSTALL_ASM_SCRIPT_VERSION.
+ASM_PACKAGE_VERSION=1.10.4-asm.6+config2
+INSTALL_ASM_SCRIPT_VERSION=install_asm_1.10.4-asm.6-config2
+# ASM Upgrade Guide: Check out README.md of the same directory.
+
+# The name of the context for your Kubeflow cluster
+PACKAGE_DIR?=$(shell pwd)/..
+
+YQ=docker run --rm -v "$(PACKAGE_DIR)/":/workdir mikefarah/yq:4
+NAME=$(shell $(YQ) e '.data.name' kptconfig/kpt-setter-config.yaml)
+PROJECT=$(shell $(YQ) e '.data."gcloud.core.project"' kptconfig/kpt-setter-config.yaml)
+LOCATION=$(shell $(YQ) e '.data.location' kptconfig/kpt-setter-config.yaml)
+
+UPSTREAM=upstream
+
+.PHONY: download-install-asm-script
+download-install-asm-script:
+	curl https://storage.googleapis.com/csm-artifacts/asm/$(INSTALL_ASM_SCRIPT_VERSION) > install_asm;
+	chmod +x install_asm
+# Official documentation of downloading install_asm: https://cloud.google.com/service-mesh/docs/scripted-install/asm-onboarding#downloading_the_script
+# It cannot control the patch version so we won't use this approach for now.
+# cd ./asm && { \
+# 	curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_1.9 > install_asm; \
+# 	curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_1.9.sha256 > install_asm.sha256; \
+# 	sha256sum -c --ignore-missing install_asm.sha256; \
+# 	chmod +x install_asm; \
+# 	cd -;}
+
+.PHONY: download-asm-package
+download-asm-package:
+	rm -rf asm.tar.gz
+	curl -LJ https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/archive/refs/tags/$(ASM_PACKAGE_VERSION).tar.gz -o asm.tar.gz 
+	
+	rm -rf ./package
+	mkdir package
+	tar -xf asm.tar.gz --strip-components=1 -C package 
+
+.PHONY: install-asm
+install-asm: download-install-asm-script download-asm-package
+	./install_asm \
+	--project_id $(PROJECT) \
+	--cluster_name $(NAME) \
+	--cluster_location $(LOCATION) \
+	--mode install \
+	--enable_all \
+	--custom_overlay ./package/asm/istio/options/iap-operator.yaml \
+	--custom_overlay ./options/ingressgateway-iap.yaml
+
+
+.PHONY: apply
+apply: install-asm
+
+.PHONY: hydrate
+hydrate: # download-asmcli asmcli-validate asmcli-precheck
+# There is no hydration for ASM, it is taken care by install_asm/asmcli. 
+# In the future, we will migrate to use asmcli, you can validate readiness using following commands.
+# make asmcli-validate 
+# make asmcli-precheck
+# Note: Require existence of a cluster before running the commands above.
+
+# Commands below are for asmcli, asmcli is in alpha state, we plan to migrate from install_asm to asmcli when ready.
+.PHONY: download-asmcli
+download-asmcli: 
+	curl https://storage.googleapis.com/csm-artifacts/asm/asmcli_alpha > asmcli
+	curl https://storage.googleapis.com/csm-artifacts/asm/asmcli_alpha.sha256 > asmcli.sha256
+	chmod +x asmcli
+
+.PHONY: asmcli-validate
+asmcli-validate:
+	./asmcli validate \
+	--project_id $(PROJECT) \
+	--cluster_name $(NAME) \
+	--cluster_location $(LOCATION) \
+	--output_dir $(UPSTREAM) \
+	--ca mesh_ca \
+	--custom_overlay ./$(UPSTREAM)/asm/istio/options/iap-operator.yaml \
+	--custom_overlay ./options/ingressgateway-iap.yaml \
+	--option legacy-default-ingressgateway \
+	--verbose
+
+
+.PHONY: asmcli-install
+asmcli-install: download-asmcli
+# --fleet_id is optional. If not specified, use project_id
+	./asmcli install \
+	--project_id $(PROJECT) \
+	--cluster_name $(NAME) \
+	--cluster_location $(LOCATION) \
+	--output_dir $(UPSTREAM) \
+	--enable_all \
+	--ca mesh_ca \
+	--custom_overlay ./$(UPSTREAM)/asm/istio/options/iap-operator.yaml \
+	--custom_overlay ./options/ingressgateway-iap.yaml \
+	--option legacy-default-ingressgateway \
+	--verbose
+
+.PHONY: asmcli-precheck
+asmcli-precheck:
+	pushd $(UPSTREAM) && ./istioctl experimental precheck && popd
+
+# Note about install gateways
+# https://cloud.google.com/service-mesh/docs/unified-install/install#install_gateways

--- a/kubeflow/asm/deprecated/README.md
+++ b/kubeflow/asm/deprecated/README.md
@@ -15,7 +15,7 @@
 * [Official ASM installation guide with install_asm approach](https://cloud.google.com/service-mesh/docs/scripted-install/gke-install)
 * [Integrate ASM with IAP](https://cloud.google.com/service-mesh/docs/iap-integration )
 
-### Upgrade steps
+### Upgrade steps for the legacy ASM installation approach
 
 You can upgrade ASM by first installing ASM tools' package, and installing new ASM to cluster. Migrate existing workload to new ASM, then deprecate the old ASM:
 

--- a/kubeflow/asm/deprecated/README.md
+++ b/kubeflow/asm/deprecated/README.md
@@ -4,6 +4,11 @@
 
 ## Upgrade ASM
 
+> **Note**
+> Use of `asmcli` is recommended for versions above v1.10. Begining v1.12
+> `install_asm` is no longer supported. Please, [upgrade
+> instructions](https://cloud.google.com/service-mesh/docs/upgrade-path-old-versions-gke).
+
 ### Documentations
 
 * [Kubeflow upgrade ASM guide](https://www.kubeflow.org/docs/distributions/gke/deploy/upgrade/#upgrade-asm-anthos-service-mesh)

--- a/kubeflow/asm/deprecated/README.md
+++ b/kubeflow/asm/deprecated/README.md
@@ -6,7 +6,7 @@
 
 > **Note**
 > Use of `asmcli` is recommended for versions above v1.10. Begining v1.12
-> `install_asm` is no longer supported. Please, [upgrade
+> `install_asm` is no longer supported. Please, see [upgrade
 > instructions](https://cloud.google.com/service-mesh/docs/upgrade-path-old-versions-gke).
 
 ### Documentations

--- a/kubeflow/asm/deprecated/README.md
+++ b/kubeflow/asm/deprecated/README.md
@@ -4,15 +4,15 @@
 
 ## Upgrade ASM
 
-> **Note**
-> Use of `asmcli` is recommended for versions above v1.10. Begining v1.12
-> `install_asm` is no longer supported. Please, see [upgrade
+> **Note**:
+> Use of `asmcli` is recommended for versions above v1.10. Beginning v1.12
+> `install_asm` is no longer supported. Refer to [upgrade
 > instructions](https://cloud.google.com/service-mesh/docs/upgrade-path-old-versions-gke).
 
 ### Documentations
 
 * [Kubeflow upgrade ASM guide](https://www.kubeflow.org/docs/distributions/gke/deploy/upgrade/#upgrade-asm-anthos-service-mesh)
-* [Official ASM instalation guide with install_asm approach](https://cloud.google.com/service-mesh/docs/scripted-install/gke-install)
+* [Official ASM installation guide with install_asm approach](https://cloud.google.com/service-mesh/docs/scripted-install/gke-install)
 * [Integrate ASM with IAP](https://cloud.google.com/service-mesh/docs/iap-integration )
 
 ### Upgrade steps
@@ -49,4 +49,4 @@ You can upgrade ASM by first installing ASM tools' package, and installing new A
     make apply
     ```
 
-* (Optional): Deprecate old ASM by following `Complete the transistion -> Migrate` in [Deploy and Redeploy workloads](https://cloud.google.com/service-mesh/docs/scripted-install/gke-upgrade#deploying_and_redeploying_workloads).
+* (Optional): Deprecate old ASM by following `Complete the transition -> Migrate` in [Deploy and Redeploy workloads](https://cloud.google.com/service-mesh/docs/scripted-install/gke-upgrade#deploying_and_redeploying_workloads).

--- a/kubeflow/asm/deprecated/README.md
+++ b/kubeflow/asm/deprecated/README.md
@@ -1,0 +1,47 @@
+# Anthos Service Mesh (ASM)
+
+[Anthos Service Mesh introduction](https://cloud.google.com/anthos/service-mesh)
+
+## Upgrade ASM
+
+### Documentations
+
+* [Kubeflow upgrade ASM guide](https://www.kubeflow.org/docs/distributions/gke/deploy/upgrade/#upgrade-asm-anthos-service-mesh)
+* [Official ASM instalation guide with install_asm approach](https://cloud.google.com/service-mesh/docs/scripted-install/gke-install)
+* [Integrate ASM with IAP](https://cloud.google.com/service-mesh/docs/iap-integration )
+
+### Upgrade steps
+
+You can upgrade ASM by first installing ASM tools' package, and installing new ASM to cluster. Migrate existing workload to new ASM, then deprecate the old ASM:
+
+* Get a list of stable versions of `install_asm` and `config packages` by running this command:
+
+    ```
+    curl https://storage.googleapis.com/csm-artifacts/asm/STABLE_VERSIONS
+    ```
+
+    For example: `1.9.2-asm.1+config4:install_asm_1.9.2-asm.1-config4`. The part before colon symbol (1.9.2-asm.1+config4) should be used for `ASM_PACKAGE_VERSION` in Makefile of current directory.The part after colon symbol (install_asm_1.9.2-asm.1-config4) should be used for `INSTALL_ASM_SCRIPT_VERSION`.
+
+* Determine the ASM version you want to upgrade, follow the instruction above to update `ASM_PACKAGE_VERSION` and `INSTALL_ASM_SCRIPT_VERSION` in Makefile. Then run the following command under `kubeflow/common/asm` to install new ASM version.
+
+    ```
+    make install-asm
+    ```
+
+* Update `kubeflow/env.sh` for the ASM version, this looks like format: **asm-192-1**, and you can find the exact value in istiod pod's label as well.
+    
+    For example: You can find label `istio.io/rev: asm-192-1` in istiod-asm-192-1 service. Then run `source env.sh` under `kubeflow/` folder.
+
+* Configure kpt setter value under `kubeflow/` for all Kubeflow components which require to set ASM namespace label:
+
+    ```
+    bash kpt-set.sh
+    ```
+
+* Follow official doc [Deploy and Redeploy workloads](https://cloud.google.com/service-mesh/docs/scripted-install/gke-upgrade#deploying_and_redeploying_workloads) to migrate workloads in each namespace, including user namespace created in [Kubeflow multi-tenancy](https://www.kubeflow.org/docs/components/multi-tenancy/getting-started/). In the case of Kubeflow cluster deployment, you can rerun `make apply` under `kubeflow/` directory to upgrade workloads. (Note: You can also run `make hydrate` before `make apply` to compare the difference of resource manifests.)
+
+    ```
+    make apply
+    ```
+
+* (Optional): Deprecate old ASM by following `Complete the transistion -> Migrate` in [Deploy and Redeploy workloads](https://cloud.google.com/service-mesh/docs/scripted-install/gke-upgrade#deploying_and_redeploying_workloads).

--- a/kubeflow/common/iap-ingress/base/config-map.yaml
+++ b/kubeflow/common/iap-ingress/base/config-map.yaml
@@ -55,6 +55,8 @@ data:
     [ -z ${SERVICE} ] && echo Error SERVICE must be set && exit 1
     [ -z ${INGRESS_NAME} ] && echo Error INGRESS_NAME must be set && exit 1
 
+    __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
     PROJECT=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
     if [ -z ${PROJECT} ]; then
       echo Error unable to fetch PROJECT from compute metadata
@@ -100,10 +102,8 @@ data:
       echo BACKEND_ID=${BACKEND_ID}
 
       JWT_AUDIENCE="/projects/${PROJECT_NUM}/global/backendServices/${BACKEND_ID}"
-      
-      # Use kubectl patch.
-      echo patch JWT audience: ${JWT_AUDIENCE}
-      kubectl patch RequestAuthentication ingress-jwt -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/jwtRules/0/audiences/0", "value": "'${JWT_AUDIENCE}'"}]'
+      echo "Upsert RequestAuthentication with JWT audience: ${JWT_AUDIENCE}"
+      sed "s|JWT_AUDIENCE|${JWT_AUDIENCE}|" ${__dir}/policy.yaml | kubectl apply -n ${NAMESPACE} -f -
 
       echo "Clearing lock on service annotation"
       kubectl patch svc "${SERVICE}" -n istio-system -p "{\"metadata\": { \"annotations\": {\"backendlock\": \"\" }}}"
@@ -167,12 +167,11 @@ data:
       echo health check URI is ${HEALTH_CHECK_URI}
 
       # See: https://cloud.google.com/service-mesh/docs/iap-integration#deploying_the_load_balancer
-      HC_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
+      HC_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="status-port")].nodePort}')
       echo Setting BackendConfig healthCheck.port to: ${HC_INGRESS_PORT}
       kubectl patch backendconfig iap-backendconfig -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/healthCheck/port", "value": '${HC_INGRESS_PORT}'}]'
       
-        #HC_INGRESS_PATH=$(kubectl -n istio-system get deployments istio-ingressgateway -o jsonpath='{.spec.template.spec.containers[?(@.name=="istio-proxy")].readinessProbe.httpGet.path}')
-      HC_INGRESS_PATH=healthz
+      HC_INGRESS_PATH=$(kubectl -n istio-system get deployments istio-ingressgateway -o jsonpath='{.spec.template.spec.containers[?(@.name=="istio-proxy")].readinessProbe.httpGet.path}')
       echo Setting BackendConfig healthCheck.requestPath to ${HC_INGRESS_PATH}
       kubectl patch backendconfig iap-backendconfig -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/healthCheck/requestPath", "value": "'${HC_INGRESS_PATH}'"}]'
     }

--- a/kubeflow/common/iap-ingress/base/config-map.yaml
+++ b/kubeflow/common/iap-ingress/base/config-map.yaml
@@ -167,11 +167,12 @@ data:
       echo health check URI is ${HEALTH_CHECK_URI}
 
       # See: https://cloud.google.com/service-mesh/docs/iap-integration#deploying_the_load_balancer
-      HC_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="status-port")].nodePort}')
+      HC_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
       echo Setting BackendConfig healthCheck.port to: ${HC_INGRESS_PORT}
       kubectl patch backendconfig iap-backendconfig -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/healthCheck/port", "value": '${HC_INGRESS_PORT}'}]'
       
-      HC_INGRESS_PATH=$(kubectl -n istio-system get deployments istio-ingressgateway -o jsonpath='{.spec.template.spec.containers[?(@.name=="istio-proxy")].readinessProbe.httpGet.path}')
+        #HC_INGRESS_PATH=$(kubectl -n istio-system get deployments istio-ingressgateway -o jsonpath='{.spec.template.spec.containers[?(@.name=="istio-proxy")].readinessProbe.httpGet.path}')
+      HC_INGRESS_PATH=healthz
       echo Setting BackendConfig healthCheck.requestPath to ${HC_INGRESS_PATH}
       kubectl patch backendconfig iap-backendconfig -n ${NAMESPACE} --type json -p '[{"op": "replace", "path": "/spec/healthCheck/requestPath", "value": "'${HC_INGRESS_PATH}'"}]'
     }

--- a/kubeflow/env.sh
+++ b/kubeflow/env.sh
@@ -52,4 +52,4 @@ export REGION=us-central1
 # Preferred zone of Cloud SQL. Note, ZONE should be in REGION.
 export ZONE=us-central1-c
 # Anthos Service Mesh version label
-export ASM_LABEL=asm-1134-4
+export ASM_LABEL=asm-1132-5

--- a/kubeflow/env.sh
+++ b/kubeflow/env.sh
@@ -52,4 +52,4 @@ export REGION=us-central1
 # Preferred zone of Cloud SQL. Note, ZONE should be in REGION.
 export ZONE=us-central1-c
 # Anthos Service Mesh version label
-export ASM_LABEL=asm-1104-6
+export ASM_LABEL=asm-1134-4

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -109,7 +109,7 @@ if [ -d common/istio/upstream/ ]; then
     rm -rf common/istio/upstream/
 fi
 mkdir -p common/istio
-kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/common/istio-1-9/@${KUBEFLOW_MANIFESTS_VERSION}" common/istio/upstream/
+kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/common/istio-1-13/@${KUBEFLOW_MANIFESTS_VERSION}" common/istio/upstream/
 rm common/istio/upstream/Kptfile
 
 if [ -d common/cert-manager/upstream/ ]; then

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -109,7 +109,7 @@ if [ -d common/istio/upstream/ ]; then
     rm -rf common/istio/upstream/
 fi
 mkdir -p common/istio
-kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/common/istio-1-13/@${KUBEFLOW_MANIFESTS_VERSION}" common/istio/upstream/
+kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/common/istio-1-11/@${KUBEFLOW_MANIFESTS_VERSION}" common/istio/upstream/
 rm common/istio/upstream/Kptfile
 
 if [ -d common/cert-manager/upstream/ ]; then


### PR DESCRIPTION
Upgrading ASM to 1.13:
- Changed installation process to use `asmcli` tool instead of `install_asm` tool
- Using `istio-1-11` from Manifests as it is currently sufficient. Planning to switch to `istio-1-14` once ASM v 1.14 is released
- Updated healthCheck configuration:
    - New requestPath: /healthz
    - New port: "http2"

Tested run on [end-2-end MNIST example](https://github.com/kubeflow/pipelines/blob/master/samples/contrib/kubeflow-e2e-mnist/kubeflow-e2e-mnist.ipynb)