### PR TITLE
(fix) User "system:serviceaccount:istio-system:kf-admin" cannot list resource "pods" in API group "" in the namespace "istio-system

### DIFF
--- a/kubeflow/common/iap-ingress/base/cluster-role.yaml
+++ b/kubeflow/common/iap-ingress/base/cluster-role.yaml
@@ -9,6 +9,7 @@ rules:
   - services
   - configmaps
   - secrets
+  - pods
   verbs:
   - get
   - list


### PR DESCRIPTION
Grant pods listing permissions to `kf-admin` KSA to fix backend-updater errors:

```
Error from server (Forbidden): pods is forbidden: User "system:serviceaccount:istio-system:kf-admin" cannot list resource "pods" in API group "" in the namespace "istio-system
```