### PR TITLE
Upgrade to v1.6.0

### DIFF
--- a/kubeflow/apps/pipelines/pull-upstream.sh
+++ b/kubeflow/apps/pipelines/pull-upstream.sh
@@ -17,7 +17,7 @@
 set -ex
 
 # TODO: Use kubeflow/pipelines once https://github.com/kubeflow/pipelines/pull/6595 is resolved.
-export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.3
+export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.4
 export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
 # export KUBEFLOW_PIPELINES_VERSION=upgradekpt # Other attempted branches: krmignore, kubeflow14
 # export KUBEFLOW_PIPELINES_REPO=https://github.com/zijianjoy/pipelines.git

--- a/kubeflow/apps/pipelines/pull-upstream.sh
+++ b/kubeflow/apps/pipelines/pull-upstream.sh
@@ -30,8 +30,8 @@ if [ $# -eq 2 ]
 fi
 
 # TODO: Use kubeflow/pipelines once https://github.com/kubeflow/pipelines/pull/6595 is resolved.
-export KUBEFLOW_PIPELINES_VERSION=$2
-export KUBEFLOW_PIPELINES_REPO=$1
+KUBEFLOW_PIPELINES_VERSION=$2
+KUBEFLOW_PIPELINES_REPO=$1
 # export KUBEFLOW_PIPELINES_VERSION=upgradekpt # Other attempted branches: krmignore, kubeflow14
 # export KUBEFLOW_PIPELINES_REPO=https://github.com/zijianjoy/pipelines.git
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"

--- a/kubeflow/apps/pipelines/pull-upstream.sh
+++ b/kubeflow/apps/pipelines/pull-upstream.sh
@@ -22,7 +22,7 @@
 #   Print messages for debugging
 set -ex
 
-if [ $# -eq 2 ]
+if [ $# -ne 2 ]
   then
     echo "Provide input values for KUBEFLOW_PIPELINES_REPO and KUBEFLOW_PIPELINES_VERSION.
     E.g. ./apps/pipelines/pull_upstream.sh https://github.com/kubeflow/pipelines.git 2.0.0-alpha.4"

--- a/kubeflow/apps/pipelines/pull-upstream.sh
+++ b/kubeflow/apps/pipelines/pull-upstream.sh
@@ -13,8 +13,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+#
+# Pulls manifests for Kubeflow Pipelines into the ./upstream folder
+# Arguments:
+#   $1 must be a Git repository. E.g. https://github.com/kubeflow/pipelines.git
+#   $2 must be a TAG or Commit SHA sum. E.g. 2.0.0-alpha.4
+# Output:
+#   Print messages for debugging
 set -ex
+
+if [ $# -eq 0 ]
+  then
+    echo "Provide input values for KUBEFLOW_PIPELINES_REPO and KUBEFLOW_PIPELINES_VERSION.
+    E.g. ./apps/pipelines/pull_upstream.sh https://github.com/kubeflow/pipelines.git 2.0.0-alpha.4"
+    exit 1
+fi
 
 # TODO: Use kubeflow/pipelines once https://github.com/kubeflow/pipelines/pull/6595 is resolved.
 export KUBEFLOW_PIPELINES_VERSION=$2

--- a/kubeflow/apps/pipelines/pull-upstream.sh
+++ b/kubeflow/apps/pipelines/pull-upstream.sh
@@ -22,7 +22,7 @@
 #   Print messages for debugging
 set -ex
 
-if [ $# -eq 0 ]
+if [ $# -eq 2 ]
   then
     echo "Provide input values for KUBEFLOW_PIPELINES_REPO and KUBEFLOW_PIPELINES_VERSION.
     E.g. ./apps/pipelines/pull_upstream.sh https://github.com/kubeflow/pipelines.git 2.0.0-alpha.4"

--- a/kubeflow/apps/pipelines/pull-upstream.sh
+++ b/kubeflow/apps/pipelines/pull-upstream.sh
@@ -17,8 +17,8 @@
 set -ex
 
 # TODO: Use kubeflow/pipelines once https://github.com/kubeflow/pipelines/pull/6595 is resolved.
-export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.4
-export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
+export KUBEFLOW_PIPELINES_VERSION=$2
+export KUBEFLOW_PIPELINES_REPO=$1
 # export KUBEFLOW_PIPELINES_VERSION=upgradekpt # Other attempted branches: krmignore, kubeflow14
 # export KUBEFLOW_PIPELINES_REPO=https://github.com/zijianjoy/pipelines.git
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"

--- a/kubeflow/asm/Makefile
+++ b/kubeflow/asm/Makefile
@@ -10,8 +10,8 @@
 # The part before colon symbol should be used for ASM_PACKAGE_VERSION.
 # The part after colon symbol should be used for ASMCLI_SCRIPT_VERSION.
 
-ASM_PACKAGE_VERSION=1.13.2-asm.5+config2
-ASMCLI_SCRIPT_VERSION=asmcli_1.13.2-asm.5-config2
+ASM_PACKAGE_VERSION=1.14.1-asm.3+config6
+ASMCLI_SCRIPT_VERSION=asmcli_1.14.1-asm.3-config6
 
 # The name of the context for your Kubeflow cluster
 PACKAGE_DIR?=$(shell pwd)/..

--- a/kubeflow/common/iap-ingress/Makefile
+++ b/kubeflow/common/iap-ingress/Makefile
@@ -24,6 +24,10 @@ check-iap:
 
 .PHONY: pod-reset
 pod-reset:
+	kubectl wait deployments/iap-enabler --for=condition=available --timeout=30s
+	kubectl wait deployments/cloud-endpoints-enabler --for=condition=available --timeout=30s
+	kubectl rollout status --watch --timeout=30s statefulset/backend-updater
+	timeout 30
 	# Kick the IAP pod because we will reset the policy and need to patch it.
 	# TODO(https://github.com/kubeflow/gcp-blueprints/issues/14)
 	kubectl --context=$(KFCTXT) -n istio-system delete deployment iap-enabler

--- a/kubeflow/common/iap-ingress/Makefile
+++ b/kubeflow/common/iap-ingress/Makefile
@@ -27,7 +27,7 @@ pod-reset:
 	kubectl wait deployments/iap-enabler --for=condition=available --timeout=30s
 	kubectl wait deployments/cloud-endpoints-enabler --for=condition=available --timeout=30s
 	kubectl rollout status --watch --timeout=30s statefulset/backend-updater
-	timeout 30
+	sleep 30
 	# Kick the IAP pod because we will reset the policy and need to patch it.
 	# TODO(https://github.com/kubeflow/gcp-blueprints/issues/14)
 	kubectl --context=$(KFCTXT) -n istio-system delete deployment iap-enabler

--- a/kubeflow/contrib/application/kustomization.yaml
+++ b/kubeflow/contrib/application/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ./upstream/v3 # kpt-set: ${application-v3}

--- a/kubeflow/contrib/kserve/Makefile
+++ b/kubeflow/contrib/kserve/Makefile
@@ -10,7 +10,11 @@ KFCTXT=$(NAME)
 .PHONY: apply
 apply: hydrate
 # Apply App kserve
+	mkdir $(build_dir)/runtimes
+	mv $(build_dir)/*clusterservingruntime* $(build_dir)/runtimes/
 	kubectl --context=$(KFCTXT) apply -f $(build_dir)
+	kubectl wait --for condition=established --timeout=30s crd/clusterservingruntimes.serving.kserve.io
+	kubectl --context=$(KFCTXT) apply -f $(build_dir)/runtimes
 	kubectl --context=$(KFCTXT) patch cm config-domain --namespace knative-serving --type merge -p '{"data":{"$(NAME).endpoints.$(PROJECT).cloud.goog": ""}}'
 
 .PHONY: hydrate

--- a/kubeflow/contrib/kserve/Makefile
+++ b/kubeflow/contrib/kserve/Makefile
@@ -9,12 +9,19 @@ KFCTXT=$(NAME)
 
 .PHONY: apply
 apply: hydrate
-# Apply App kserve
+	# Apply App kserve
+	# To resolve https://github.com/kubeflow/gcp-blueprints/issues/384,
+	# we apply runtime manifests after the corresponding CRDs become available
+	# 1. Move runtime manifests into a separate subdirectory
 	mkdir $(build_dir)/runtimes
 	mv $(build_dir)/serving*clusterservingruntime* $(build_dir)/runtimes/
+	# 2. Apply the remaining manifests
 	kubectl --context=$(KFCTXT) apply -f $(build_dir)
+	# 3. Wait until CRDs become available or exit in 30s
 	kubectl wait --for condition=established --timeout=30s crd/clusterservingruntimes.serving.kserve.io
+	# 4. Apply runtime manifests
 	kubectl --context=$(KFCTXT) apply -f $(build_dir)/runtimes
+	# Patch knative configmap
 	kubectl --context=$(KFCTXT) patch cm config-domain --namespace knative-serving --type merge -p '{"data":{"$(NAME).endpoints.$(PROJECT).cloud.goog": ""}}'
 
 .PHONY: hydrate

--- a/kubeflow/contrib/kserve/Makefile
+++ b/kubeflow/contrib/kserve/Makefile
@@ -11,7 +11,7 @@ KFCTXT=$(NAME)
 apply: hydrate
 # Apply App kserve
 	mkdir $(build_dir)/runtimes
-	mv $(build_dir)/*clusterservingruntime* $(build_dir)/runtimes/
+	mv $(build_dir)/serving*clusterservingruntime* $(build_dir)/runtimes/
 	kubectl --context=$(KFCTXT) apply -f $(build_dir)
 	kubectl wait --for condition=established --timeout=30s crd/clusterservingruntimes.serving.kserve.io
 	kubectl --context=$(KFCTXT) apply -f $(build_dir)/runtimes

--- a/kubeflow/env.sh
+++ b/kubeflow/env.sh
@@ -52,4 +52,4 @@ export REGION=us-central1
 # Preferred zone of Cloud SQL. Note, ZONE should be in REGION.
 export ZONE=us-central1-c
 # Anthos Service Mesh version label
-export ASM_LABEL=asm-1132-5
+export ASM_LABEL=asm-1141-3

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -22,7 +22,7 @@ export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.4
 export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
 
 # Pull Kubeflow Pipelines upstream manifests.
-./apps/pipelines/pull-upstream.sh
+./apps/pipelines/pull-upstream.sh ${KUBEFLOW_PIPELINES_REPO} ${KUBEFLOW_PIPELINES_VERSION}
 # TODO: kpt get strategy: --strategy force-delete-replace
 
 # apps/ related manifest

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -16,7 +16,7 @@
 
 set -ex
 
-export KUBEFLOW_MANIFESTS_VERSION=v1.6.0-rc.1
+export KUBEFLOW_MANIFESTS_VERSION=v1.6.0
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
 
 # Pull Kubeflow Pipelines upstream manifests.

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -18,8 +18,8 @@ set -ex
 
 export KUBEFLOW_MANIFESTS_VERSION=v1.6.0
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
-KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.4
-KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
+export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.4
+export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
 
 # Pull Kubeflow Pipelines upstream manifests.
 ./apps/pipelines/pull-upstream.sh ${KUBEFLOW_PIPELINES_REPO} ${KUBEFLOW_PIPELINES_VERSION}

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -18,6 +18,8 @@ set -ex
 
 export KUBEFLOW_MANIFESTS_VERSION=v1.6.0
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
+export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.4
+export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
 
 # Pull Kubeflow Pipelines upstream manifests.
 ./apps/pipelines/pull-upstream.sh
@@ -145,7 +147,7 @@ if [ -d contrib/metacontroller/upstream/ ]; then
     rm -rf contrib/metacontroller/upstream/
 fi
 mkdir -p contrib/metacontroller
-kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/contrib/metacontroller/@${KUBEFLOW_MANIFESTS_VERSION}" contrib/metacontroller/upstream/
+kpt pkg get "${KUBEFLOW_PIPELINES_REPO}/manifests/kustomize/third-party/metacontroller/@${KUBEFLOW_PIPELINES_REPO}" contrib/metacontroller/upstream/
 rm contrib/metacontroller/upstream/Kptfile
 
 if [ -d contrib/kserve/models-web-app/upstream ]; then

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -18,8 +18,8 @@ set -ex
 
 export KUBEFLOW_MANIFESTS_VERSION=v1.6.0
 export KUBEFLOW_MANIFESTS_REPO=https://github.com/kubeflow/manifests.git
-export KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.4
-export KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
+KUBEFLOW_PIPELINES_VERSION=2.0.0-alpha.4
+KUBEFLOW_PIPELINES_REPO=https://github.com/kubeflow/pipelines.git
 
 # Pull Kubeflow Pipelines upstream manifests.
 ./apps/pipelines/pull-upstream.sh ${KUBEFLOW_PIPELINES_REPO} ${KUBEFLOW_PIPELINES_VERSION}

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -140,7 +140,7 @@ if [ -d contrib/metacontroller/upstream/ ]; then
     rm -rf contrib/metacontroller/upstream/
 fi
 mkdir -p contrib/metacontroller
-kpt pkg get "${KUBEFLOW_PIPELINES_REPO}/manifests/kustomize/third-party/metacontroller/@${KUBEFLOW_PIPELINES_REPO}" contrib/metacontroller/upstream/
+kpt pkg get "${KUBEFLOW_PIPELINES_REPO}/manifests/kustomize/third-party/metacontroller/@${KUBEFLOW_PIPELINES_VERSION}" contrib/metacontroller/upstream/
 rm contrib/metacontroller/upstream/Kptfile
 
 if [ -d contrib/kserve/models-web-app/upstream ]; then

--- a/kubeflow/pull-upstream.sh
+++ b/kubeflow/pull-upstream.sh
@@ -136,13 +136,6 @@ kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/common/user-namespace/@${KUBEFLOW_MANIFE
 rm common/user-namespace/upstream/Kptfile
 
 # contrib/ related manifest
-if [ -d contrib/application/upstream/ ]; then
-    rm -rf contrib/application/upstream/
-fi
-mkdir -p contrib/application
-kpt pkg get "${KUBEFLOW_MANIFESTS_REPO}/contrib/application/@${KUBEFLOW_MANIFESTS_VERSION}" contrib/application/upstream/
-rm contrib/application/upstream/Kptfile
-
 if [ -d contrib/metacontroller/upstream/ ]; then
     rm -rf contrib/metacontroller/upstream/
 fi


### PR DESCRIPTION
Preparing for KF 1.6.0 release on GCP:

- Updated upstream [Manifests](/kubeflow/manifests) to v1.6.0
- Upgraded ASM to 1.14.1 to match Istio in [Manifests](/kubeflow/manifests) to v1.6.0
- Upgraded KFP to 2.0.0-alpha.4. Now KFP version and repo have to be set in the main **kubeflow/pull-upstream.sh** instead of **kubeflow/apps/pipelines/pull-upstream.sh**
- Fixed Kserve race condition during deployment
- Added an extra delay that ensures 30+ sec execution for `backend-updater`, `iap-enabler`, and `cloud-endpoints-enabler` workloads to improve deployment stability
- Changed upstream for **contrib/metacontroller** to [KFP](/kubeflow/pipelines)
- Deprecated and removed **contrib/application**

Testing:
- [x] Tested on GKE 1.21
- [x] Tested on GKE 1.22